### PR TITLE
Fix in Fatalf call

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,5 @@
-test:
+test: vet
 	go test
+
+vet:
+	go vet

--- a/spiffe_test.go
+++ b/spiffe_test.go
@@ -39,6 +39,6 @@ func TestGetUrisInSubjectAltName(t *testing.T) {
 	}
 
 	if (len(uris) > 0) {
-		t.Fatalf("Expected to have no URIs but got %v URIs", golden, len(uris))
+		t.Fatalf("Expected to have no URIs but got %v URIs", len(uris))
 	}
 }


### PR DESCRIPTION
- Fix for wrong number of args for format in Fatalf call.
- Adding "go vet" target to Makefile to report suspicious constructs.