### PR TITLE
Expose function to parse URI from parsed certificates

### DIFF
--- a/spiffe.go
+++ b/spiffe.go
@@ -2,9 +2,9 @@ package spiffe
 
 import (
 	"crypto/x509"
-	"encoding/pem"
-	"encoding/asn1"
 	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/pem"
 	"errors"
 )
 
@@ -67,9 +67,21 @@ func getExtensionsFromAsn1ObjectIdentifier(certificate *x509.Certificate, id asn
 	return extensions
 }
 
-// GetUrisInSubjectAltName parses an X.509 certificate in PEM format and gets the URIs from the SAN extension
-func GetUrisInSubjectAltName(certificateString string) (uris []string, err error) {
-	block, _ := pem.Decode([]byte(certificateString))
+// GetUrisInSubjectAltName takes a parsed X.509 certificate and gets the URIs from the SAN extension.
+func GetUrisInSubjectAltName(cert *x509.Certificate) (uris []string, err error) {
+	for _, ext := range getExtensionsFromAsn1ObjectIdentifier(cert, oidExtensionSubjectAltName) {
+		uris, err = getUrisFromSANExtension(ext.Value)
+		if err != nil {
+			return
+		}
+	}
+
+	return uris, nil
+}
+
+// GetUrisInSubjectAltNameEncoded parses a PEM-encoded X.509 certificate and gets the URIs from the SAN extension.
+func GetUrisInSubjectAltNameEncoded(encodedCertificate string) (uris []string, err error) {
+	block, _ := pem.Decode([]byte(encodedCertificate))
 	if block == nil {
 		return uris, errors.New("failed to decode certificate PEM")
 	}
@@ -79,12 +91,5 @@ func GetUrisInSubjectAltName(certificateString string) (uris []string, err error
 		return uris, errors.New("failed to parse certificate: " + err.Error())
 	}
 
-	for _, ext := range getExtensionsFromAsn1ObjectIdentifier(cert, oidExtensionSubjectAltName) {
-		uris, err = getUrisFromSANExtension(ext.Value)
-		if err != nil {
-			return
-		}
-	}
-
-	return uris, nil
+	return GetUrisInSubjectAltName(cert)
 }

--- a/spiffe.go
+++ b/spiffe.go
@@ -10,7 +10,7 @@ import (
 
 var oidExtensionSubjectAltName = asn1.ObjectIdentifier{2, 5, 29, 17}
 
-func getUrisFromSANExtension(sanExtension []byte) (uris []string, err error) {
+func getURINamesFromSANExtension(sanExtension []byte) (uris []string, err error) {
 	// RFC 5280, 4.2.1.6
 
 	// SubjectAltName ::= GeneralNames
@@ -68,9 +68,9 @@ func getExtensionsFromAsn1ObjectIdentifier(certificate *x509.Certificate, id asn
 }
 
 // GetUrisInSubjectAltName takes a parsed X.509 certificate and gets the URIs from the SAN extension.
-func GetUrisInSubjectAltName(cert *x509.Certificate) (uris []string, err error) {
+func GetURINamesFromCertificate(cert *x509.Certificate) (uris []string, err error) {
 	for _, ext := range getExtensionsFromAsn1ObjectIdentifier(cert, oidExtensionSubjectAltName) {
-		uris, err = getUrisFromSANExtension(ext.Value)
+		uris, err = getURINamesFromSANExtension(ext.Value)
 		if err != nil {
 			return
 		}
@@ -80,7 +80,7 @@ func GetUrisInSubjectAltName(cert *x509.Certificate) (uris []string, err error) 
 }
 
 // GetUrisInSubjectAltNameEncoded parses a PEM-encoded X.509 certificate and gets the URIs from the SAN extension.
-func GetUrisInSubjectAltNameEncoded(encodedCertificate string) (uris []string, err error) {
+func GetURINamesFromPEM(encodedCertificate string) (uris []string, err error) {
 	block, _ := pem.Decode([]byte(encodedCertificate))
 	if block == nil {
 		return uris, errors.New("failed to decode certificate PEM")
@@ -91,5 +91,5 @@ func GetUrisInSubjectAltNameEncoded(encodedCertificate string) (uris []string, e
 		return uris, errors.New("failed to parse certificate: " + err.Error())
 	}
 
-	return GetUrisInSubjectAltName(cert)
+	return GetURINamesFromCertificate(cert)
 }

--- a/spiffe_test.go
+++ b/spiffe_test.go
@@ -14,12 +14,12 @@ func getCertificateFromFile(t *testing.T, certFilePath string) string {
 	return string(certificateString)
 }
 
-func TestGetUrisInSubjectAltName(t *testing.T) {
+func TestGetURINamesFromPEM(t *testing.T) {
 	certPEM := getCertificateFromFile(t, "testdata/leaf.cert.pem")
 
 	var golden = "spiffe://dev.acme.com/path/service"
 
-	uris, err := GetUrisInSubjectAltNameEncoded(string(certPEM))
+	uris, err := GetURINamesFromPEM(string(certPEM))
 	if err != nil {
 		t.Error(err)
 	}
@@ -33,7 +33,7 @@ func TestGetUrisInSubjectAltName(t *testing.T) {
 	}
 
 	certPEM = getCertificateFromFile(t, "testdata/intermediate.cert.pem")
-	uris, err = GetUrisInSubjectAltNameEncoded(string(certPEM))
+	uris, err = GetURINamesFromPEM(string(certPEM))
 	if err == nil {
 		t.Fatal("Expected to fail")
 	}

--- a/spiffe_test.go
+++ b/spiffe_test.go
@@ -1,8 +1,8 @@
 package spiffe
 
 import (
-	"testing"
 	"io/ioutil"
+	"testing"
 )
 
 func getCertificateFromFile(t *testing.T, certFilePath string) string {
@@ -11,7 +11,7 @@ func getCertificateFromFile(t *testing.T, certFilePath string) string {
 		t.Fatal(err)
 	}
 
-	return string(certificateString);
+	return string(certificateString)
 }
 
 func TestGetUrisInSubjectAltName(t *testing.T) {
@@ -19,26 +19,26 @@ func TestGetUrisInSubjectAltName(t *testing.T) {
 
 	var golden = "spiffe://dev.acme.com/path/service"
 
-	uris, err := GetUrisInSubjectAltName(string(certPEM))
+	uris, err := GetUrisInSubjectAltNameEncoded(string(certPEM))
 	if err != nil {
-		t.Error(err);
+		t.Error(err)
 	}
 
-	if (len(uris) == 1) {
-		if (uris[0] != golden) {
+	if len(uris) == 1 {
+		if uris[0] != golden {
 			t.Fatalf("Expected '%v' but got '%v'", golden, uris[0])
 		}
-	} else 	{
+	} else {
 		t.Fatalf("Expected 1 URI but got '%v'", len(uris))
 	}
 
 	certPEM = getCertificateFromFile(t, "testdata/intermediate.cert.pem")
-	uris, err = GetUrisInSubjectAltName(string(certPEM))
+	uris, err = GetUrisInSubjectAltNameEncoded(string(certPEM))
 	if err == nil {
 		t.Fatal("Expected to fail")
 	}
 
-	if (len(uris) > 0) {
+	if len(uris) > 0 {
 		t.Fatalf("Expected to have no URIs but got %v URIs", len(uris))
 	}
 }


### PR DESCRIPTION
Cherry picked from #5 with an add'l commit to update API function name

> Proposed change to make this library easier to consume. I'd like to hook this up in square/certigo so that certigo can display URI SANs when dumping a certificate, but I don't want to round-trip to the PEM-encoded version. There's also some gofmt changes (related: you should apply gofmt automatically on all commits).
> 
> Note this change slightly alters the API due to the fact that I renamed GetUrisInSubjectAltName to GetUrisInSubjectAltNameEncoded, let me know if that's not ok and I can change the naming to something else.

Please let me know if/where I need to update consumers

@csstaub @amartinezfayo @y2bishop2y