### PR TITLE
all: added CLI, FGetURINamesFromPEM and godoc reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,28 @@
-# go-spiffe library
+# go-spiffe library [![GoDoc](https://godoc.org/github.com/spiffe/go-spiffe?status.svg)](https://godoc.org/github.com/spiffe/go-spiffe)
 
-### Overview
+## Overview
 
 The go-spiffe library provides functionality to parse and verify SPIFFE
 identities encoded in X.509 certificates as described in the
 [SPIFFE Standards](https://github.com/spiffe/spiffe/tree/master/standards).
 
-#### func GetUrisInSubjectAltName
-
-```go
-func GetUrisInSubjectAltName(certificateString string) (uris []string, err error)
+## Installing it
+```shell
+go get -u -v github.com/spiffe/go-spiffe
 ```
-Parses an X.509 certificate in PEM format and gets the URIs from the Subject
-Alternative Name extension.
+
+## Importing it in your Go code
+
+See examples in [examples_test.go](./example_test.go)
+or visit the [GoDoc](https://godoc.org/github.com/spiffe/go-spiffe) for more information
+
+## Installing the command line interface
+The command line interface can be used to retrieve and view URIs stored
+in the SAN extension of certificates
+
+```shell
+go get -u -v github.com/spiffe/go-spiffe/cmd/spiffe
+spiffe testdata/leaf.cert.pem $HOME/certs/proj.pem
+Path:: #1: "testdata/leaf.cert.pem"
+  URI #1: "spiffe://dev.acme.com/path/service"
+```

--- a/cmd/spiffe/main.go
+++ b/cmd/spiffe/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	spiffe "github.com/spiffe/go-spiffe"
+)
+
+func main() {
+	// Make log not print out time information
+	log.SetFlags(0)
+
+	if len(os.Args) <= 1 {
+		log.Fatalf("\033[31mexpecting path [paths...] e.g\033[00m\n\tspiffe /var/lib/letsencrypt/spiffe.pem $HOME/Desktop/certs/cert.pem\033[00m\n")
+	}
+
+	seenPaths := make(map[string]bool)
+	args := os.Args[1:]
+	for i, path := range args {
+		if _, seen := seenPaths[path]; seen {
+			continue
+		}
+
+		seenPaths[path] = true
+		f, err := os.Open(path)
+		if err != nil {
+			log.Printf("\n#%d: err=%v\n", i, err)
+			continue
+		}
+
+		uris, err := spiffe.FGetURINamesFromPEM(f)
+		_ = f.Close()
+
+		if err != nil {
+			log.Printf("\n#%d: parseErr=%v\n", i, err)
+			continue
+		}
+		if len(uris) == 0 {
+			log.Printf("\n#%d: no uris could be parsed\n", i)
+			continue
+		}
+
+		log.Printf("Path:: #%d: %q\n", i+1, path)
+		for j, uri := range uris {
+			log.Printf("\tURI #%d: %q\n", j+1, uri)
+		}
+	}
+}

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,51 @@
+package spiffe_test
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	spiffe "github.com/spiffe/go-spiffe"
+)
+
+func Example_FGetURINamesFromPEM() {
+	log.SetFlags(0)
+
+	f, err := os.Open("./testdata/leaf.cert.pem")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer f.Close()
+
+	uris, err := spiffe.FGetURINamesFromPEM(f)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if len(uris) == 0 {
+		log.Fatal("did not get any URIs")
+	}
+	for i, uri := range uris {
+		fmt.Printf("#%d:: URI:%q", i, uri)
+	}
+
+	// Output:
+	//  #0:: URI:"spiffe://dev.acme.com/path/service"
+}
+
+func Example_GetURINamesFromPEM() {
+	log.SetFlags(0)
+
+	uris, err := spiffe.GetURINamesFromPEM(goodCert)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if len(uris) == 0 {
+		log.Fatal("did not get any URIs")
+	}
+	for i, uri := range uris {
+		fmt.Printf("#%d:: URI:%q", i, uri)
+	}
+
+	// Output:
+	//  #0:: URI:"spiffe://dev.acme.com/path/service"
+}

--- a/spiffe.go
+++ b/spiffe.go
@@ -6,6 +6,8 @@ import (
 	"encoding/asn1"
 	"encoding/pem"
 	"errors"
+	"io"
+	"io/ioutil"
 )
 
 var oidExtensionSubjectAltName = asn1.ObjectIdentifier{2, 5, 29, 17}
@@ -81,9 +83,15 @@ func GetURINamesFromCertificate(cert *x509.Certificate) (uris []string, err erro
 
 // GetUrisInSubjectAltNameEncoded parses a PEM-encoded X.509 certificate and gets the URIs from the SAN extension.
 func GetURINamesFromPEM(encodedCertificate string) (uris []string, err error) {
-	block, _ := pem.Decode([]byte(encodedCertificate))
+	return uriNamesFromPEM([]byte(encodedCertificate))
+}
+
+var errNilBlock = errors.New("failed to decode certificate PEM")
+
+func uriNamesFromPEM(encodedCertificate []byte) (uris []string, err error) {
+	block, _ := pem.Decode(encodedCertificate)
 	if block == nil {
-		return uris, errors.New("failed to decode certificate PEM")
+		return uris, errNilBlock
 	}
 
 	cert, err := x509.ParseCertificate(block.Bytes)
@@ -92,4 +100,14 @@ func GetURINamesFromPEM(encodedCertificate string) (uris []string, err error) {
 	}
 
 	return GetURINamesFromCertificate(cert)
+}
+
+// FGetURINamesFromPEM retrieves URIs from the SAN extension of a
+// PEM-encoded X.509 certificate, whose content is in the provided io.Reader.
+func FGetURINamesFromPEM(f io.Reader) (uris []string, err error) {
+	blob, err := ioutil.ReadAll(f)
+	if err != nil {
+		return nil, err
+	}
+	return uriNamesFromPEM(blob)
 }

--- a/spiffe_test.go
+++ b/spiffe_test.go
@@ -1,8 +1,11 @@
-package spiffe
+package spiffe_test
 
 import (
 	"io/ioutil"
+	"strings"
 	"testing"
+
+	spiffe "github.com/spiffe/go-spiffe"
 )
 
 func getCertificateFromFile(t *testing.T, certFilePath string) string {
@@ -14,12 +17,12 @@ func getCertificateFromFile(t *testing.T, certFilePath string) string {
 	return string(certificateString)
 }
 
+const golden = "spiffe://dev.acme.com/path/service"
+
 func TestGetURINamesFromPEM(t *testing.T) {
 	certPEM := getCertificateFromFile(t, "testdata/leaf.cert.pem")
 
-	var golden = "spiffe://dev.acme.com/path/service"
-
-	uris, err := GetURINamesFromPEM(string(certPEM))
+	uris, err := spiffe.GetURINamesFromPEM(string(certPEM))
 	if err != nil {
 		t.Error(err)
 	}
@@ -33,7 +36,98 @@ func TestGetURINamesFromPEM(t *testing.T) {
 	}
 
 	certPEM = getCertificateFromFile(t, "testdata/intermediate.cert.pem")
-	uris, err = GetURINamesFromPEM(string(certPEM))
+	uris, err = spiffe.GetURINamesFromPEM(string(certPEM))
+	if err == nil {
+		t.Fatal("Expected to fail")
+	}
+
+	if len(uris) > 0 {
+		t.Fatalf("Expected to have no URIs but got %v URIs", len(uris))
+	}
+}
+
+const (
+	goodCert = `
+-----BEGIN CERTIFICATE-----
+MIIE1DCCArygAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwPzELMAkGA1UEBhMCVVMx
+FzAVBgNVBAoMDnRlc3QxLmFjbWUuY29tMRcwFQYDVQQDDA5JbnRlcm1lZGlhZXRD
+QTAeFw0xNzA3MTkxNjUwMjBaFw0xNzA3MjkxNjUwMjBaMDUxCzAJBgNVBAYTAlVT
+MRcwFQYDVQQKDA50ZXN0MS5hY21lLmNvbTENMAsGA1UEAwwEYmxvZzCCASIwDQYJ
+KoZIhvcNAQEBBQADggEPADCCAQoCggEBAKm8P47lABp4+rz2nN+QYrxedbaFVWoF
+FuoSkqcHsafMwbMrN+kI6wJVtlbwviDvxWFJ92q0H71QNFybTsmof3KUN/kYCp7P
++LKhBrN0ttWI5q6v5eDrjN0VdtVdnlZOYmJFbvETOgfK/qXKNRRM8HYW0tdqrtEw
+CR5dIu53xVUSViBdwXpuy2c5W2mFn1gxTpdW+3hbZsL1pHrU9qPWLtTgl/KY8kjs
+I7KW1cIcinE4SJomhB5L/4emhxKGY+kEa2+fN9IPjjvKSMOw9kiBKk1GHZcIY5EA
+O3TIfUk3fysPzi5qA0su/bNtPQy1uXgXS10xUlV7pqRPvHjiNzgFkXUCAwEAAaOB
+4zCB4DAJBgNVHRMEAjAAMB0GA1UdDgQWBBRVQ91jSOONzVr1VGBdJOlPN+3XxTBg
+BgNVHSMEWTBXgBQ13bfx50rDZO3y2CZdHPgleFUEoKE7pDkwNzELMAkGA1UEBhMC
+VVMxFzAVBgNVBAoMDnRlc3QxLmFjbWUuY29tMQ8wDQYDVQQDDAZSb290Q0GCAhAA
+MA4GA1UdDwEB/wQEAwIDqDATBgNVHSUEDDAKBggrBgEFBQcDATAtBgNVHREEJjAk
+hiJzcGlmZmU6Ly9kZXYuYWNtZS5jb20vcGF0aC9zZXJ2aWNlMA0GCSqGSIb3DQEB
+CwUAA4ICAQBp2+rtUxt1VmNM/vi6PwoSoYzWFmQ2nc4OM7bsOG4uppU54wRYZ+T7
+c42EcrpyBgWn+rWHT1Hi6SNcmloKHydaUTZ4pq3IlKKnBNqwivU5BzIxYLDrhR/U
+wd9s1tgmLvADqkQa1XjjSFn5Auoj1R640ry4qpw8IOusdm6wVhru4ssRnHX4E2uR
+jQe7b3ws38aZhjtL78Ip0BB4yPxWJRp/WmEoT33QP+cZhA4IYWECxNODr6DSJeq2
+VNu/6JACGrNfM2Sjt4Wxz+nIa3cKDNCA6PR8StTUTcoQ6ZBzpn+n/Q1xSRIOJz6N
+hgfkyb9O7HAMdAP+TxehjqG3gh5Ky2DgYMCIZOztVzsuOb1DGJe/kGUKeRJLl2/O
+QwkctwUOcVIxckNu6OvclriFzvoXObqO77XeCI2V1Vef0wGTWlWNOdbFa4708Y7f
+5UdwInYQUi87RFDnc1SDU4Jrsv4KzZiv9FCfDg8pCBIdWpWT7DAuI0d7i7PZ+iFt
+ZZ6sb/YDkyiDXU4ar/dja0FDE2r7jsN9D+FfW49+iDvXr4ELQyhZpW3Zr1Ojwm58
+CJzjZwbRYiVwPBRsKmiYfO1E7esvw3CmjK5chfz8c40f6/APDro9ZmYNBRv2CnJy
+t/DtcM/GpAhBbLP9Tk7kPB41v5fRIxVDo50Iz/qvkr37pQ4RsejSFg==
+-----END CERTIFICATE-----
+`
+	badCert = `
+-----BEGIN CERTIFICATE-----
+MIIFiDCCA3CgAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwNzELMAkGA1UEBhMCVVMx
+FzAVBgNVBAoMDnRlc3QxLmFjbWUuY29tMQ8wDQYDVQQDDAZSb290Q0EwHhcNMTcw
+NzE5MTY1MDIwWhcNMTcxMDI3MTY1MDIwWjA/MQswCQYDVQQGEwJVUzEXMBUGA1UE
+CgwOdGVzdDEuYWNtZS5jb20xFzAVBgNVBAMMDkludGVybWVkaWFldENBMIICIjAN
+BgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAph7QhbUKEjMWu2R/WXIc8RR0ymCL
+njJTm0D5duTe7V2hklLhCo1KnZAjvDiDX9r85UfEja5MYItHmFF4HOZjSG6nY3Yg
+Mm5hdJM7Jmv9NJR8DJInROabfRcaPdugs2UQ41jCEygIoWiZ9+yVlZ21MNW0yQdI
+JHUNndQfXpS7dBdKw6fUqzZgpdzo86mAapZDIPL7gXv6MW8JhbvQCm+bg7SRIJOD
+t/a1T0nHPNuwxdDWjGcmJEQRknffL8pheDlW9sMAd/4BtIeaWUEb3JjdDoaJ9SWU
+tCgGRZOMnmry8npJnssyoLUtIPuk8949REOUB15nT94EhTtb1BMdiuD8P8HOHWC6
+mcxpJCsKlCFmOQpES6WROqjckQJ0f/xPOdKAdI9W0Eg3TRtibV9XTfTvv8SPug9/
+6FnkdpwF5xlJ/XcuW8GtpHUZNQ0NyxjUh2rQRAbwdTMeCvhx5fPHpT2kc6PIlzLw
+h4Pt0Xvc1cNt2iJOVDqs75HvvUe4RYTfdqlK5385u/s2cxQrLuB4owJrTyrqc3yM
+L/0h5JXr9P+T+axrd5WQWz2ngiaimli2vxZTR++RfBnyCgQGTiY+9UUOYYgHh6hJ
+CGUPY77DsKuTfIXYlra+c65FKFAcZrC4vt1CLtBqW2mBy7U868c0L9PZ1g3+WGvA
+FmnZA6MgUKQE0i0CAwEAAaOBlTCBkjAdBgNVHQ4EFgQUNd238edKw2Tt8tgmXRz4
+JXhVBKAwHwYDVR0jBBgwFoAUUeBRd0yew4JtInksRTlbz71YwtEwDwYDVR0TAQH/
+BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAYYwLwYDVR0eAQH/BCUwI6AhMA+GDS5kZXYu
+YWNtZS5jb20wDoYMZGV2LmFjbWUuY29tMA0GCSqGSIb3DQEBCwUAA4ICAQBLljbI
+ekm5/uhFbc/aCAlomwGkXFvyMXx7eD7Pimzn4H31nYvQ5ha2M0536JC/mH1xi7nK
+OOMuSBAqjpALoRk4+3O5s6r9BN8KKhcI4jDKHqOSBe38K+Ad06B52yxYyL6YmJwk
+Zlazf3KvExzUWS0t4ehNuI2HJvvwEitMpOF3hhwAYk3v/x2YBtpglH+yZC4Sfoma
+ItjFWeD+DA0bVAMJiErz8Pq91avnC8SPpPXiPJVOaBhaNc8po6x6cwSqY6RnI2/K
+0kUWXXH65Pz0JYru53ALzy4ouwJItcgMvzZPGVaojxEbGDrjXEkWIGresFrw1Ijr
+IyrQUqWa9wW6ik+IQOb6m3FZYB8jMO7nhop9Ywm9uoSmFRg6RsP2AWHBMYP7lZqw
+fx3HjrAvc3ycIZ2tSPkdLd5n8YuL31CVpa9aGwT5dYzIVd/eFUrCUIGV2j8XHgkL
+gMPr8JhNPAG0B4rRpEXmK3HHybo3s0M8i80Lit98xzupNpng97xKT7jJBSinNTdt
+/2uU7diHQM7aPNmNG+Wu3GXVt/MZuDMSFrh9AHl0A/Y4mNu6KKqRMJuvsfy/j1DD
+fDGmAkjHrspiorTruphHk+cymJfjAGqZ0l6il4Wi5w4R5jrxnJMhkxbjr/PG5xCS
++ZKPPNZbpPIY54oQ2bHkuaQgzJ7us4ZW7gxgbw==
+-----END CERTIFICATE-----
+`
+)
+
+func TestFGetURINamesFromPEM(t *testing.T) {
+	uris, err := spiffe.FGetURINamesFromPEM(strings.NewReader(goodCert))
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(uris) == 1 {
+		if uris[0] != golden {
+			t.Fatalf("Expected '%v' but got '%v'", golden, uris[0])
+		}
+	} else {
+		t.Fatalf("Expected 1 URI but got '%v'", len(uris))
+	}
+
+	uris, err = spiffe.FGetURINamesFromPEM(strings.NewReader(badCert))
 	if err == nil {
 		t.Fatal("Expected to fail")
 	}


### PR DESCRIPTION
Fixes #7

- Added copy+pastable examples to show the package can be used, in
example_test.go.

- Added a godoc reference so that users can get the latest
references of the code without us having to manually update
the README.md file each time.

- Implemented a CLI that is go gettable and can be used on the
commandline to inspect URIs in certificates for example
```shell
$ go get github.com/spiffe/go-spiffe/cmd/spiffe
$ spiffe $HOME/certs/leaf.cert.pem
Path:: #1: "testdata/leaf.cert.pem"
  URI #1: "spiffe://dev.acme.com/path/service"
```

- Implemented a convenience method that takes in an io.Reader which
can then be easily used in programs that say read from files, as the
CLI does
```go
package main

import (
  "io"
  "log"
  "os"

  spiffe "github.com/spiffe/go-spiffe"
)

func main() {
  log.SetFlags(0)

  var f io.Reader
  if len(os.Args) <= 1 {
    // Expecting to read from stdin e.g
    // $ cat
    f = os.Stdin
  } else {
    rf, err := os.Open(os.Args[1])
    if err != nil {
      log.Fatal(err)
    }
    defer rf.Close()
    f = rf
  }

  uris, err := spiffe.FuriNamesFromPEM(f)
  if err != nil {
    log.Fatal(err)
  }
  if len(uris) == 0 {
    log.Fatal("did not get any URIs")
  }
  for i, uri := range uris {
    log.Printf("#%d:: URI:%q", i, uri)
  }
}
```

which when run gives
```shell
$ cat $GOPATH/src/github.com/spiffe/go-spiffe/testdata/leaf.cert.pem | go run spiffe-cli.go
\#0:: URI:"spiffe://dev.acme.com/path/service"
```