### PR TITLE
Adds a link to the Workload API library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # go-spiffe library [![GoDoc](https://godoc.org/github.com/spiffe/go-spiffe?status.svg)](https://godoc.org/github.com/spiffe/go-spiffe)
 
+**Note: This library does not provide an interface to the SPIFFE Workload API. However a Go library that does provide that interface is available [as part of the SPIRE project](https://github.com/spiffe/spire/tree/master/api/workload).**
+
 ## Overview
 
 The go-spiffe library provides functionality to parse and verify SPIFFE


### PR DESCRIPTION
Unlike the c-spiffe and java-spiffe libraries, the go-spiffe library doesn't actually provide an interface to the workload API, which might confuse some people. A link to a Go library that does perform this is provided.