### PR TITLE
Fix comments on spiffe id validation modes

### DIFF
--- a/spiffe/id.go
+++ b/spiffe/id.go
@@ -140,7 +140,7 @@ func AllowAny() ValidationMode {
 	return validationMode{}
 }
 
-// Allows a well-formed SPIFFE ID for the specific trust domain (e.g. spiffe://domain.test/workload)
+// Allows a well-formed SPIFFE ID for the specific trust domain (e.g. spiffe://domain.test)
 func AllowTrustDomain(trustDomain string) ValidationMode {
 	return validationMode{
 		options: validationOptions{
@@ -171,7 +171,7 @@ func AllowAnyTrustDomain() ValidationMode {
 	}
 }
 
-// Allows a well-formed SPIFFE ID for a workload belonging to any trust domain (e.g. spiffe://domain.test).
+// Allows a well-formed SPIFFE ID for a workload belonging to any trust domain (e.g. spiffe://domain.test/workload).
 func AllowAnyTrustDomainWorkload() ValidationMode {
 	return validationMode{
 		options: validationOptions{


### PR DESCRIPTION
Add or remove path to make sure every example given for a
spiffe.ValidationMode is a valid SPIFFE ID according to that mode.