### PR TITLE
Add extra checks to verify peer certificate

### DIFF
--- a/spiffe/tls_verify.go
+++ b/spiffe/tls_verify.go
@@ -28,6 +28,16 @@ func VerifyPeerCertificate(peerChain []*x509.Certificate, trustDomainRoots map[s
 		return nil, err
 	}
 
+	if peer.IsCA {
+		return nil, errors.New("cannot validate peer which is a CA")
+	}
+	if peer.KeyUsage != x509.KeyUsageCertSign {
+		return nil, errors.New("cannot validate peer with KeyCertSign")
+	}
+	if peer.KeyUsage != x509.KeyUsageCRLSign {
+		return nil, errors.New("cannot validate peer with KeyCrlSign")
+	}
+
 	roots, ok := trustDomainRoots[trustDomainID]
 	if !ok {
 		return nil, fmt.Errorf("no roots for peer trust domain %q", trustDomainID)


### PR DESCRIPTION
This PR resolves #25 

I've added checking for:
- CA field is set to false
- keyCertSign is not set
- cRLSign is not set

I'm not sure how to check if the certificate is a leaf, though (or even if that's a request that makes sense beyond checking that CA is false).