### PR TITLE
Add get spiffe id method

### DIFF
--- a/spiffe/tls_peer.go
+++ b/spiffe/tls_peer.go
@@ -297,7 +297,7 @@ func AdaptVerifyPeerCertificate(p *TLSPeer, expectPeer ExpectPeerFunc) func([][]
 
 // ListenTLS is a convenience wrapper for listening for remote peers using
 // credentials obtained from the workload API. If more control is required it
-// is recomended to use the TLSPeer instead.
+// is recommended to use the TLSPeer instead.
 func ListenTLS(ctx context.Context, network, addr string, expectPeer ExpectPeerFunc) (net.Listener, error) {
 	tlsPeer, err := NewTLSPeer()
 	if err != nil {

--- a/spiffe/tls_verify.go
+++ b/spiffe/tls_verify.go
@@ -8,39 +8,33 @@ import (
 	"github.com/spiffe/go-spiffe/internal"
 )
 
-// VerifyPeerCertificate verifies the provided peer certificate chain using the
-// set trust domain roots. The expectPeerFn callback is used to check the peer
-// ID after the chain of trust has been verified to assert that the chain
-// belongs to the intended peer.
-func VerifyPeerCertificate(peerChain []*x509.Certificate, trustDomainRoots map[string]*x509.CertPool, expectPeerFn ExpectPeerFunc) ([][]*x509.Certificate, error) {
+// verifyPeerCertificate verifies the provided peer certificate chain using the
+// set trust domain roots.
+func verifyPeerCertificate(peerChain []*x509.Certificate, trustDomainRoots map[string]*x509.CertPool) (string, [][]*x509.Certificate, error) {
 	switch {
 	case len(peerChain) == 0:
-		return nil, errors.New("no peer certificates")
+		return "", nil, errors.New("no peer certificates")
 	case len(trustDomainRoots) == 0:
-		return nil, errors.New("at least one trust domain root is required")
-	case expectPeerFn == nil:
-		return nil, errors.New("expectPeerFn callback is required")
+		return "", nil, errors.New("at least one trust domain root is required")
 	}
 
 	peer := peerChain[0]
+	switch {
+	case peer.IsCA:
+		return "", nil, errors.New("cannot validate peer which is a CA")
+	case peer.KeyUsage&x509.KeyUsageCertSign > 0:
+		return "", nil, errors.New("cannot validate peer with KeyCertSign key usage")
+	case peer.KeyUsage&x509.KeyUsageCRLSign > 0:
+		return "", nil, errors.New("cannot validate peer with KeyCrlSign key usage")
+	}
 	peerID, trustDomainID, err := getIDsFromCertificate(peer)
 	if err != nil {
-		return nil, err
-	}
-
-	if peer.IsCA {
-		return nil, errors.New("cannot validate peer which is a CA")
-	}
-	if peer.KeyUsage&x509.KeyUsageCertSign > 0 {
-		return nil, errors.New("cannot validate peer with KeyCertSign key usage")
-	}
-	if peer.KeyUsage&x509.KeyUsageCRLSign > 0 {
-		return nil, errors.New("cannot validate peer with KeyCrlSign key usage")
+		return "", nil, err
 	}
 
 	roots, ok := trustDomainRoots[trustDomainID]
 	if !ok {
-		return nil, fmt.Errorf("no roots for peer trust domain %q", trustDomainID)
+		return "", nil, fmt.Errorf("no roots for peer trust domain %q", trustDomainID)
 	}
 
 	verifiedChains, err := peer.Verify(x509.VerifyOptions{
@@ -50,6 +44,23 @@ func VerifyPeerCertificate(peerChain []*x509.Certificate, trustDomainRoots map[s
 		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
 	})
 	if err != nil {
+		return "", nil, err
+	}
+
+	return peerID, verifiedChains, nil
+}
+
+// VerifyPeerCertificate verifies the provided peer certificate chain using the
+// set trust domain roots. The expectPeerFn callback is used to check the peer
+// ID after the chain of trust has been verified to assert that the chain
+// belongs to the intended peer.
+func VerifyPeerCertificate(peerChain []*x509.Certificate, trustDomainRoots map[string]*x509.CertPool, expectPeerFn ExpectPeerFunc) ([][]*x509.Certificate, error) {
+	if expectPeerFn == nil {
+		return nil, errors.New("expectPeerFn callback is required")
+	}
+
+	peerID, verifiedChains, err := verifyPeerCertificate(peerChain, trustDomainRoots)
+	if err != nil {
 		return nil, err
 	}
 
@@ -58,4 +69,15 @@ func VerifyPeerCertificate(peerChain []*x509.Certificate, trustDomainRoots map[s
 	}
 
 	return verifiedChains, nil
+}
+
+// GetSpiffeIDFromX509 extracts the SPIFFE ID and verifies the provided peer certificate chain using the
+// set trust domain root.
+func GetSpiffeIDFromX509(peerChain []*x509.Certificate, trustBundle map[string]*x509.CertPool) (string, error) {
+	peerID, _, err := verifyPeerCertificate(peerChain, trustBundle)
+	if err != nil {
+		return "", err
+	}
+
+	return peerID, nil
 }

--- a/spiffe/tls_verify_test.go
+++ b/spiffe/tls_verify_test.go
@@ -127,6 +127,13 @@ func TestVerifyPeerCertificate(t *testing.T) {
 			err:    `no roots for peer trust domain "spiffe://domain1.test"`,
 		},
 		{
+			name:   "root as peer",
+			chain:  ca1.Roots(),
+			roots:  roots1,
+			expect: ExpectAnyPeer(),
+			err:    "cannot validate peer which is a CA",
+		},
+		{
 			name:   "fails peer id expectation",
 			chain:  peer1,
 			roots:  roots1,

--- a/uri/uri_test.go
+++ b/uri/uri_test.go
@@ -35,7 +35,7 @@ func TestGetURINamesFromPEM(t *testing.T) {
 	}
 
 	certPEM = getCertificateFromFile(t, "../testdata/intermediate.cert.pem")
-	uris, err = GetURINamesFromPEM(string(certPEM))
+	uris, err = GetURINamesFromPEM(certPEM)
 	if err != nil {
 		t.Fatalf("Failed with %v", err)
 	}


### PR DESCRIPTION
Add method to get a SPIFFE ID from a validated x509 certificate using a provided map of trust domains.