### PR TITLE
Add bundle.RootCas method

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -1,0 +1,88 @@
+// Package bundle implements a SPIFFE-compliant bundle type.
+package bundle
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/zeebo/errs"
+	"gopkg.in/square/go-jose.v2"
+)
+
+const (
+	x509SVIDUse = "x509-svid"
+	jwtSVIDUse  = "jwt-svid"
+)
+
+// Bundle is a SPIFFE bundle object. It follows the definitions given in the
+// SPIFFE standard:
+//
+// https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE_Trust_Domain_and_Bundle.md#4-spiffe-bundle-format
+type Bundle struct {
+	// SPIFFE bundles are represented as an RFC 7517 compliant JWK Set.
+	jose.JSONWebKeySet
+
+	// Sequence is a monotonically increasing integer that is changed whenever
+	// the contents of the bundle are updated.
+	Sequence uint64 `json:"spiffe_sequence,omitempty"`
+
+	// RefreshHint indicates how often a consumer should check back for updates
+	// (in seconds).
+	RefreshHint int `json:"spiffe_refresh_hint,omitempty"`
+}
+
+// SPIFFEInvalidJWK is used to describe why a key is not SPIFFE-compliant.
+type SPIFFEInvalidJWK struct {
+	jose.JSONWebKey
+	reason error
+}
+
+// Decode reads a json document from a Reader interface and turns it into a
+// bundle object.
+func Decode(r io.Reader) (*Bundle, error) {
+	doc := new(Bundle)
+	if err := json.NewDecoder(r).Decode(doc); err != nil {
+		return nil, fmt.Errorf("failed to decode bundle: %v", err)
+	}
+
+	return doc, nil
+}
+
+// ValidateKeys validates if the keys contained in a JSONWebKey array are
+// SPIFFE-compliant. It returns two separated slices for valid and invalid keys.
+func ValidateKeys(keys []jose.JSONWebKey) ([]jose.JSONWebKey, []*SPIFFEInvalidJWK) {
+	invalid := []*SPIFFEInvalidJWK{}
+	valid := []jose.JSONWebKey{}
+
+	for i, key := range keys {
+		switch key.Use {
+		case x509SVIDUse:
+			if len(key.Certificates) != 1 {
+				invalid = append(invalid, &SPIFFEInvalidJWK{
+					JSONWebKey: key,
+					reason:     errs.New("expected a single certificate in x509-svid entry %d; got %d", i, len(key.Certificates)),
+				})
+				continue
+			}
+			valid = append(valid, key)
+
+		case jwtSVIDUse:
+			valid = append(valid, key)
+
+		case "":
+			invalid = append(invalid, &SPIFFEInvalidJWK{
+				JSONWebKey: key,
+				reason:     errs.New("missing use for key entry %d", i),
+			})
+
+		default:
+			invalid = append(invalid, &SPIFFEInvalidJWK{
+				JSONWebKey: key,
+				reason:     errs.New("unrecognized use %q for key entry %d", key.Use, i),
+			})
+		}
+	}
+
+	return valid, invalid
+}

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -2,6 +2,7 @@
 package bundle
 
 import (
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -61,6 +62,19 @@ func (b *Bundle) KeysForUse(use Use) []jose.JSONWebKey {
 		}
 	}
 	return keys
+}
+
+// RootCAs provide RootCAs from bundle
+func (b *Bundle) RootCAs() []*x509.Certificate {
+	var certs []*x509.Certificate
+
+	for _, key := range b.KeysForUse(UseX509SVID) {
+		if len(key.Certificates) > 0 {
+			certs = append(certs, key.Certificates...)
+		}
+	}
+
+	return certs
 }
 
 // Decode reads a json document from a Reader interface and turns it into a

--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -1,0 +1,194 @@
+package bundle
+
+import (
+	"crypto/x509"
+	"encoding/base64"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/spiffetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecode(t *testing.T) {
+	testCases := []struct {
+		name        string
+		doc         string
+		errContains string
+		sequence    uint64
+		refreshHint int
+	}{
+		{
+			name:        "Fails because it is not a json document",
+			doc:         "not a json",
+			errContains: "failed to decode bundle",
+		},
+		{
+			name:        "Success",
+			doc:         `{"spiffe_refresh_hint": 10, "spiffe_sequence": 2}`,
+			refreshHint: 10,
+			sequence:    2,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			r := httptest.NewRecorder()
+			_, err := r.Write([]byte(testCase.doc))
+			require.NoError(t, err)
+
+			b, err := Decode(r.Result().Body)
+			if testCase.errContains != "" {
+				require.Contains(t, err.Error(), testCase.errContains)
+				require.Nil(t, b)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, b)
+			assert.Equal(t, b.Sequence, testCase.sequence)
+			assert.Equal(t, b.RefreshHint, testCase.refreshHint)
+
+		})
+	}
+}
+
+func TestValidateKeys(t *testing.T) {
+	ca := spiffetest.NewCA(t)
+	rootCA := ca.CreateCA().Roots()[0]
+
+	testCases := []struct {
+		name        string
+		doc         string
+		errContains string
+	}{
+		{
+			name: "unrecognized use",
+			doc: `{
+				"keys": [
+					{
+						"use": "bad stuff",
+						"kty": "EC",
+						"crv": "P-256",
+						"x": "kkEn5E2Hd_rvCRDCVMNj3deN0ADij9uJVmN-El0CJz0",
+						"y": "qNrnjhtzrtTR0bRgI2jPIC1nEgcWNX63YcZOEzyo1iA"
+					}
+				]
+			}`,
+			errContains: `unrecognized use "bad stuff" for key entry 0`,
+		},
+		{
+			name: "entry missing use",
+			doc: `{
+				"keys": [
+					{
+						"kty": "EC",
+						"crv": "P-256",
+						"x": "kkEn5E2Hd_rvCRDCVMNj3deN0ADij9uJVmN-El0CJz0",
+						"y": "qNrnjhtzrtTR0bRgI2jPIC1nEgcWNX63YcZOEzyo1iA"
+					}
+				]
+			}`,
+			errContains: "missing use for key entry 0",
+		},
+		{
+			name: "x509-svid without x5c",
+			doc: `{
+				"keys": [
+					{
+						"use": "x509-svid",
+						"kty": "EC",
+						"crv": "P-256",
+						"x": "kkEn5E2Hd_rvCRDCVMNj3deN0ADij9uJVmN-El0CJz0",
+						"y": "qNrnjhtzrtTR0bRgI2jPIC1nEgcWNX63YcZOEzyo1iA"
+					}
+				]
+			}`,
+			errContains: "expected a single certificate in x509-svid entry 0; got 0",
+		},
+		{
+			name: "x509-svid with more than one x5c",
+			doc: fmt.Sprintf(`{
+			"keys": [
+				{
+					"use": "x509-svid",
+					"kty": "EC",
+					"crv": "P-256",
+					"x": "kkEn5E2Hd_rvCRDCVMNj3deN0ADij9uJVmN-El0CJz0",
+					"y": "qNrnjhtzrtTR0bRgI2jPIC1nEgcWNX63YcZOEzyo1iA",
+					"x5c": [
+						%q,
+						%q
+					]
+				}
+			]
+		}`, x5c(rootCA), x5c(rootCA)),
+			errContains: "expected a single certificate in x509-svid entry 0; got 2",
+		},
+		{
+			name: "valid x509-svid",
+			doc: fmt.Sprintf(`{
+			"keys": [
+				{
+					"use": "x509-svid",
+					"kty": "EC",
+					"crv": "P-256",
+					"x": "kkEn5E2Hd_rvCRDCVMNj3deN0ADij9uJVmN-El0CJz0",
+					"y": "qNrnjhtzrtTR0bRgI2jPIC1nEgcWNX63YcZOEzyo1iA",
+					"x5c": [
+						%q
+					]
+				}
+			]
+		}`, x5c(rootCA)),
+		},
+
+		{
+			name: "valid jwt-svid",
+			doc: `{
+				"keys": [
+					{
+						"use": "jwt-svid",
+						"kty": "EC",
+						"crv": "P-256",
+						"kid": "key-id",
+						"x": "kkEn5E2Hd_rvCRDCVMNj3deN0ADij9uJVmN-El0CJz0",
+						"y": "qNrnjhtzrtTR0bRgI2jPIC1nEgcWNX63YcZOEzyo1iA"
+					}
+				]
+			}`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+
+			r := httptest.NewRecorder()
+			_, err := r.Write([]byte(testCase.doc))
+			require.NoError(t, err)
+
+			b, err := Decode(r.Result().Body)
+			require.NoError(t, err)
+			require.NotNil(t, b)
+
+			valid, invalid := ValidateKeys(b.Keys)
+			if testCase.errContains != "" {
+				require.Len(t, valid, 0)
+				require.Len(t, invalid, 1)
+				assert.Contains(t, invalid[0].reason.Error(), testCase.errContains)
+				return
+			}
+			assert.Len(t, invalid, 0)
+			assert.Len(t, valid, 1)
+
+		})
+	}
+}
+
+func x5c(cert *x509.Certificate) string {
+	return base64.StdEncoding.EncodeToString(cert.Raw)
+}

--- a/bundle/endpoint/client.go
+++ b/bundle/endpoint/client.go
@@ -1,0 +1,117 @@
+// Package endpoint implements a SPIFFE bundle endpoint client.
+package endpoint
+
+import (
+	"context"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/spiffe/go-spiffe/bundle"
+	spiffe_tls "github.com/spiffe/go-spiffe/tls"
+	"github.com/zeebo/errs"
+)
+
+// SPIFFEAuthConfig contains the configuration of the SPIFFE authentication
+// mechanism for authenticating the bundle endpoint.
+type SPIFFEAuthConfig struct {
+	// EndpointSpiffeID is the expected SPIFFE ID of the endpoint server.
+	EndpointSpiffeID string
+
+	// RootCAs is the set of root CA certificates used to authenticate the
+	// endpoint server.
+	RootCAs []*x509.Certificate
+}
+
+// ClientConfig contains the configuration to create a bundle endpoint client.
+type ClientConfig struct {
+	// EndpointAddress is the bundle endpoint for the trust domain.
+	EndpointAddress string
+
+	// SPIFFEAuth contains required configuration to authenticate the endpoint
+	// using SPIFFE authentication. If unset, it is assumed that the endpoint
+	// is authenticated via Web PKI.
+	SPIFFEAuth *SPIFFEAuthConfig
+}
+
+// Client is used to fetch a bundle and metadata from a bundle endpoint
+type Client interface {
+	FetchBundle(context.Context) (*bundle.Bundle, error)
+}
+
+type client struct {
+	c      ClientConfig
+	client *http.Client
+}
+
+// NewClient creates a new bundle endpoint client
+func NewClient(config ClientConfig) (Client, error) {
+	if config.EndpointAddress == "" {
+		return nil, errs.New("bundle endpoint address is required")
+	}
+
+	httpClient := &http.Client{}
+	if config.SPIFFEAuth != nil {
+		spiffeID := config.SPIFFEAuth.EndpointSpiffeID
+		if spiffeID == "" {
+			return nil, errs.New("bundle endpoint spiffe ID is required")
+		}
+		if len(config.SPIFFEAuth.RootCAs) == 0 {
+			return nil, errs.New("an initial up-to-date bundle from the remote trust domain is required")
+		}
+
+		peer := &spiffe_tls.TLSPeer{
+			SpiffeIDs:  []string{spiffeID},
+			TrustRoots: newCertPool(config.SPIFFEAuth.RootCAs...),
+		}
+		httpClient.Transport = &http.Transport{
+			TLSClientConfig: peer.NewTLSConfig(nil),
+		}
+	}
+	return &client{
+		c:      config,
+		client: httpClient,
+	}, nil
+}
+
+// FetchBundle fetches a SPIFFE bundle from a bundle endpoint.
+// Any JWK element not matching the SPIFFE specification requirements won't
+// be included in the bundle.
+func (c *client) FetchBundle(ctx context.Context) (*bundle.Bundle, error) {
+	resp, err := c.client.Get(fmt.Sprintf("https://%s", c.c.EndpointAddress))
+	if err != nil {
+		return nil, errs.New("failed to fetch bundle: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, errs.New("unexpected status %d fetching bundle: %s", resp.StatusCode, tryRead(resp.Body))
+	}
+
+	b, err := bundle.Decode(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	validKeys, _ := bundle.ValidateKeys(b.Keys)
+	b.Keys = validKeys
+
+	return b, nil
+}
+
+func tryRead(r io.Reader) string {
+	b := make([]byte, 1024)
+	n, _ := r.Read(b)
+	return string(b[:n])
+}
+
+// newCertPool creates a new *x509.CertPool based on the certificates given
+// as parameters.
+func newCertPool(certs ...*x509.Certificate) *x509.CertPool {
+	certPool := x509.NewCertPool()
+	for _, cert := range certs {
+		certPool.AddCert(cert)
+	}
+	return certPool
+}

--- a/bundle/endpoint/client.go
+++ b/bundle/endpoint/client.go
@@ -2,22 +2,25 @@
 package endpoint
 
 import (
+	"bufio"
 	"context"
+	"crypto/tls"
 	"crypto/x509"
 	"fmt"
 	"io"
 	"net/http"
 
 	"github.com/spiffe/go-spiffe/bundle"
-	spiffe_tls "github.com/spiffe/go-spiffe/tls"
+	"github.com/spiffe/go-spiffe/internal"
+	"github.com/spiffe/go-spiffe/spiffe"
 	"github.com/zeebo/errs"
 )
 
-// SPIFFEAuthConfig contains the configuration of the SPIFFE authentication
+// AuthConfig contains the configuration of the SPIFFE authentication
 // mechanism for authenticating the bundle endpoint.
-type SPIFFEAuthConfig struct {
-	// EndpointSpiffeID is the expected SPIFFE ID of the endpoint server.
-	EndpointSpiffeID string
+type AuthConfig struct {
+	// ServerID is the expected SPIFFE ID of the endpoint server.
+	ServerID string
 
 	// RootCAs is the set of root CA certificates used to authenticate the
 	// endpoint server.
@@ -26,13 +29,13 @@ type SPIFFEAuthConfig struct {
 
 // ClientConfig contains the configuration to create a bundle endpoint client.
 type ClientConfig struct {
-	// EndpointAddress is the bundle endpoint for the trust domain.
-	EndpointAddress string
+	// Address is the bundle endpoint for the trust domain.
+	Address string
 
-	// SPIFFEAuth contains required configuration to authenticate the endpoint
+	// Auth contains required configuration to authenticate the endpoint
 	// using SPIFFE authentication. If unset, it is assumed that the endpoint
 	// is authenticated via Web PKI.
-	SPIFFEAuth *SPIFFEAuthConfig
+	Auth *AuthConfig
 }
 
 // Client is used to fetch a bundle and metadata from a bundle endpoint
@@ -47,26 +50,27 @@ type client struct {
 
 // NewClient creates a new bundle endpoint client
 func NewClient(config ClientConfig) (Client, error) {
-	if config.EndpointAddress == "" {
+	if config.Address == "" {
 		return nil, errs.New("bundle endpoint address is required")
 	}
 
 	httpClient := &http.Client{}
-	if config.SPIFFEAuth != nil {
-		spiffeID := config.SPIFFEAuth.EndpointSpiffeID
+	if config.Auth != nil {
+		spiffeID := config.Auth.ServerID
 		if spiffeID == "" {
 			return nil, errs.New("bundle endpoint spiffe ID is required")
 		}
-		if len(config.SPIFFEAuth.RootCAs) == 0 {
+		if len(config.Auth.RootCAs) == 0 {
 			return nil, errs.New("an initial up-to-date bundle from the remote trust domain is required")
 		}
 
-		peer := &spiffe_tls.TLSPeer{
-			SpiffeIDs:  []string{spiffeID},
-			TrustRoots: newCertPool(config.SPIFFEAuth.RootCAs...),
+		tlsConfig, err := getTLSConfig(spiffeID, config.Auth.RootCAs)
+		if err != nil {
+			return nil, errs.New("cannot get TLS config: %v", err)
 		}
+
 		httpClient.Transport = &http.Transport{
-			TLSClientConfig: peer.NewTLSConfig(nil),
+			TLSClientConfig: tlsConfig,
 		}
 	}
 	return &client{
@@ -79,7 +83,7 @@ func NewClient(config ClientConfig) (Client, error) {
 // Any JWK element not matching the SPIFFE specification requirements won't
 // be included in the bundle.
 func (c *client) FetchBundle(ctx context.Context) (*bundle.Bundle, error) {
-	resp, err := c.client.Get(fmt.Sprintf("https://%s", c.c.EndpointAddress))
+	resp, err := c.client.Get(fmt.Sprintf("https://%s", c.c.Address))
 	if err != nil {
 		return nil, errs.New("failed to fetch bundle: %v", err)
 	}
@@ -94,24 +98,45 @@ func (c *client) FetchBundle(ctx context.Context) (*bundle.Bundle, error) {
 		return nil, err
 	}
 
-	validKeys, _ := bundle.ValidateKeys(b.Keys)
-	b.Keys = validKeys
-
 	return b, nil
 }
 
 func tryRead(r io.Reader) string {
-	b := make([]byte, 1024)
-	n, _ := r.Read(b)
-	return string(b[:n])
+	scanner := bufio.NewScanner(r)
+	scanner.Scan()
+	return scanner.Text()
 }
 
-// newCertPool creates a new *x509.CertPool based on the certificates given
-// as parameters.
-func newCertPool(certs ...*x509.Certificate) *x509.CertPool {
-	certPool := x509.NewCertPool()
-	for _, cert := range certs {
-		certPool.AddCert(cert)
+func getTLSConfig(spiffeID string, rootCAs []*x509.Certificate) (*tls.Config, error) {
+	trustDomainID, err := spiffe.TrustDomainIDFromID(spiffeID, spiffe.AllowAnyTrustDomainWorkload())
+	if err != nil {
+		return nil, errs.New("unable to get trust domain from SPIFFE ID: %v", err)
 	}
-	return certPool
+
+	roots := make(map[string]*x509.CertPool)
+	roots[trustDomainID] = internal.CertPoolFromCerts(rootCAs)
+
+	return &tls.Config{
+		ClientAuth:            tls.RequireAnyClientCert,
+		InsecureSkipVerify:    true,
+		VerifyPeerCertificate: adaptVerifyPeerCertificate(roots, spiffe.ExpectPeer(spiffeID)),
+	}, nil
+}
+
+func adaptVerifyPeerCertificate(roots map[string]*x509.CertPool, expectPeer spiffe.ExpectPeerFunc) func([][]byte, [][]*x509.Certificate) error {
+	return func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+		var certs []*x509.Certificate
+		for i, rawCert := range rawCerts {
+			cert, err := x509.ParseCertificate(rawCert)
+			if err != nil {
+				return errs.New("unable to parse certificate %d: %v", i, err)
+			}
+			certs = append(certs, cert)
+		}
+
+		if _, err := spiffe.VerifyPeerCertificate(certs, roots, expectPeer); err != nil {
+			return errs.New("unable to verify client peer chain: %v", err)
+		}
+		return nil
+	}
 }

--- a/bundle/endpoint/client_example_test.go
+++ b/bundle/endpoint/client_example_test.go
@@ -1,0 +1,89 @@
+package endpoint_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/spiffe/go-spiffe/bundle"
+	"github.com/spiffe/go-spiffe/bundle/endpoint"
+)
+
+// This is an example of the bundle endpoint client used with the the SPIFFE
+// authentication mechanism.
+// The example assumes an SPIRE implementation of the SPIFFE bundle endpoint server
+// is running on localhost:8443 under the trust domain 'spiffe://example.org'.
+func Example_client() {
+	// Load an initial up-to-date bundle from the remote trust domain (obtained
+	// through an offline exchange).
+	rootCAs, err := loadCertificate("dummy_upstream_ca.crt")
+	if err != nil {
+		fmt.Printf("Unable to load root CAs: %v", err)
+		return
+	}
+
+	// Creates the bundle client using the SPIFFE authentication mechanim
+	c, err := endpoint.NewClient(endpoint.ClientConfig{
+		EndpointAddress: "localhost:8443",
+		SPIFFEAuth: &endpoint.SPIFFEAuthConfig{
+			EndpointSpiffeID: "spiffe://example.org/spire/server",
+			RootCAs:          []*x509.Certificate{rootCAs},
+		},
+	})
+
+	if err != nil {
+		fmt.Printf("Unable to create client: %v", err)
+		return
+	}
+
+	// Fetch the bundle from the endpoint
+	b, err := c.FetchBundle(context.Background())
+	if err != nil {
+		fmt.Printf("Unable to fetch bundle: %v", err)
+		return
+	}
+
+	// Print the bundle content
+	printBundle(b)
+}
+
+func printBundle(b *bundle.Bundle) {
+	fmt.Println("Bundle fetched")
+	fmt.Printf("Sequence number: %d\n", b.Sequence)
+	fmt.Printf("Refresh hint   : %d\n", b.RefreshHint)
+	for i, key := range b.Keys {
+		fmt.Println("")
+		keyJson, err := key.MarshalJSON()
+		if err != nil {
+			fmt.Printf("Unable to marshal key %d to json: %v\n", i, err)
+			continue
+		}
+		var prettyJson bytes.Buffer
+		err = json.Indent(&prettyJson, keyJson, "", "    ")
+		if err != nil {
+			fmt.Printf("Unable to pretty print key %d %v\n", i, err)
+			continue
+		}
+
+		fmt.Printf("Key %d:\n%s\n", i, prettyJson.Bytes())
+	}
+}
+
+func loadCertificate(path string) (*x509.Certificate, error) {
+	r, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	block, _ := pem.Decode(r)
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return cert, nil
+}

--- a/bundle/endpoint/client_example_test.go
+++ b/bundle/endpoint/client_example_test.go
@@ -1,40 +1,31 @@
 package endpoint_test
 
 import (
-	"bytes"
 	"context"
 	"crypto/x509"
-	"encoding/json"
-	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 
-	"github.com/spiffe/go-spiffe/bundle"
 	"github.com/spiffe/go-spiffe/bundle/endpoint"
 )
 
 // This is an example of the bundle endpoint client used with the the SPIFFE
 // authentication mechanism.
-// The example assumes an SPIRE implementation of the SPIFFE bundle endpoint server
+// The example assumes a SPIRE implementation of the SPIFFE bundle endpoint server
 // is running on localhost:8443 under the trust domain 'spiffe://example.org'.
-func Example_client() {
-	// Load an initial up-to-date bundle from the remote trust domain (obtained
-	// through an offline exchange).
-	rootCAs, err := loadCertificate("dummy_upstream_ca.crt")
-	if err != nil {
-		fmt.Printf("Unable to load root CAs: %v", err)
-		return
-	}
+func Example() {
+	// TODO: load the initial set of trust domain root CAs (obtained through an offline exchange). These root CAs
+	// are used to bootstrap trust with the endpoint. Afterwards, the contents of the bundle returned by the endpoint
+	// should be used for future authentication.
+	var rootCAs []*x509.Certificate
 
 	// Creates the bundle client using the SPIFFE authentication mechanim
 	c, err := endpoint.NewClient(endpoint.ClientConfig{
-		EndpointAddress: "localhost:8443",
-		SPIFFEAuth: &endpoint.SPIFFEAuthConfig{
-			EndpointSpiffeID: "spiffe://example.org/spire/server",
-			RootCAs:          []*x509.Certificate{rootCAs},
+		Address: "localhost:8443",
+		Auth: &endpoint.AuthConfig{
+			ServerID: "spiffe://example.org/spire/server",
+			RootCAs:  rootCAs,
 		},
 	})
-
 	if err != nil {
 		fmt.Printf("Unable to create client: %v", err)
 		return
@@ -47,43 +38,5 @@ func Example_client() {
 		return
 	}
 
-	// Print the bundle content
-	printBundle(b)
-}
-
-func printBundle(b *bundle.Bundle) {
-	fmt.Println("Bundle fetched")
-	fmt.Printf("Sequence number: %d\n", b.Sequence)
-	fmt.Printf("Refresh hint   : %d\n", b.RefreshHint)
-	for i, key := range b.Keys {
-		fmt.Println("")
-		keyJson, err := key.MarshalJSON()
-		if err != nil {
-			fmt.Printf("Unable to marshal key %d to json: %v\n", i, err)
-			continue
-		}
-		var prettyJson bytes.Buffer
-		err = json.Indent(&prettyJson, keyJson, "", "    ")
-		if err != nil {
-			fmt.Printf("Unable to pretty print key %d %v\n", i, err)
-			continue
-		}
-
-		fmt.Printf("Key %d:\n%s\n", i, prettyJson.Bytes())
-	}
-}
-
-func loadCertificate(path string) (*x509.Certificate, error) {
-	r, err := ioutil.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-
-	block, _ := pem.Decode(r)
-	cert, err := x509.ParseCertificate(block.Bytes)
-	if err != nil {
-		return nil, err
-	}
-
-	return cert, nil
+	fmt.Printf("Bundle fetched: %+v", b)
 }

--- a/bundle/endpoint/client_example_test.go
+++ b/bundle/endpoint/client_example_test.go
@@ -38,5 +38,6 @@ func Example() {
 		return
 	}
 
-	fmt.Printf("Bundle fetched: %+v", b)
+	// TODO: use the bundle
+	_ = b
 }

--- a/bundle/endpoint/client_test.go
+++ b/bundle/endpoint/client_test.go
@@ -1,0 +1,157 @@
+package endpoint
+
+import (
+	"context"
+	"crypto"
+	"crypto/tls"
+	"crypto/x509"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/spiffetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewClient(t *testing.T) {
+	testCases := []struct {
+		name        string
+		errContains string
+		config      ClientConfig
+	}{
+		{
+			name:   "Success web PKI authentication",
+			config: ClientConfig{EndpointAddress: "localhost:9999"},
+		},
+		{
+			name: "Success SPIFFE authentication",
+			config: ClientConfig{
+				EndpointAddress: "localhost:9999",
+				SPIFFEAuth: &SPIFFEAuthConfig{
+					EndpointSpiffeID: "spiffe://example.org/bundle",
+					RootCAs:          []*x509.Certificate{&x509.Certificate{}},
+				},
+			},
+		},
+		{
+			name:        "Fail because of empty endpoint SPIFFE ID",
+			errContains: "bundle endpoint spiffe ID is required",
+			config: ClientConfig{
+				EndpointAddress: "localhost:9999",
+				SPIFFEAuth:      &SPIFFEAuthConfig{RootCAs: []*x509.Certificate{}},
+			},
+		},
+		{
+			name:        "Fail because no initial root CAs are provided",
+			errContains: "an initial up-to-date bundle from the remote trust domain is required",
+			config: ClientConfig{
+				EndpointAddress: "localhost:9999",
+				SPIFFEAuth: &SPIFFEAuthConfig{
+					EndpointSpiffeID: "spiffe://example.org/bundle",
+				},
+			},
+		},
+		{
+			name:        "Fail because of empty endpoint address",
+			errContains: "bundle endpoint address is required",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			client, err := NewClient(testCase.config)
+			if testCase.errContains != "" {
+				assert.Contains(t, err.Error(), testCase.errContains)
+				assert.Nil(t, client)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotNil(t, client)
+		})
+	}
+
+}
+
+func TestFetchBundle(t *testing.T) {
+	testCases := []struct {
+		name        string
+		spiffeID    string
+		status      int
+		body        string
+		errContains string
+	}{
+		{
+			name:     "success",
+			status:   http.StatusOK,
+			spiffeID: "spiffe://example.org/bundle",
+			body:     `{"spiffe_refresh_hint": 10}`,
+		},
+		{
+			name:        "SPIFFE ID override",
+			spiffeID:    "spiffe://otherdomain.org",
+			errContains: "SPIFFE ID mismatch",
+		},
+		{
+			name:        "non-200 status",
+			status:      http.StatusServiceUnavailable,
+			spiffeID:    "spiffe://example.org/bundle",
+			body:        "tHe SYsTEm iS DowN",
+			errContains: "unexpected status 503 fetching bundle: tHe SYsTEm iS DowN",
+		},
+		{
+			name:        "invalid bundle content",
+			status:      http.StatusOK,
+			spiffeID:    "spiffe://example.org/bundle",
+			body:        "NOT JSON",
+			errContains: "failed to decode bundle",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			serverCert, serverKey := createServerCertificate(t)
+			server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.WriteHeader(testCase.status)
+				_, _ = w.Write([]byte(testCase.body))
+			}))
+
+			server.TLS = &tls.Config{
+				Certificates: []tls.Certificate{
+					{
+						Certificate: [][]byte{serverCert.Raw},
+						PrivateKey:  serverKey,
+					},
+				},
+			}
+			server.StartTLS()
+			defer server.Close()
+
+			client, err := NewClient(ClientConfig{
+				EndpointAddress: server.Listener.Addr().String(),
+				SPIFFEAuth: &SPIFFEAuthConfig{
+					EndpointSpiffeID: testCase.spiffeID,
+					RootCAs:          []*x509.Certificate{serverCert},
+				},
+			})
+			require.NoError(t, err)
+
+			b, err := client.FetchBundle(context.Background())
+			if testCase.errContains != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), testCase.errContains)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, b)
+			require.Equal(t, uint64(0), b.Sequence)
+			require.Equal(t, 10, b.RefreshHint)
+		})
+	}
+}
+
+func createServerCertificate(t *testing.T) (*x509.Certificate, crypto.Signer) {
+	ca, signer := spiffetest.CreateCACertificate(t, nil, nil)
+	return spiffetest.CreateX509SVID(t, ca, signer, "spiffe://example.org/bundle")
+}

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,7 @@ require (
 	github.com/gogo/protobuf v1.2.1
 	github.com/golang/protobuf v1.3.1
 	github.com/stretchr/testify v1.3.0
+	github.com/zeebo/errs v1.2.2
 	google.golang.org/grpc v1.22.0
+	gopkg.in/square/go-jose.v2 v2.4.1
 )

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,9 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/zeebo/errs v1.2.2 h1:5NFypMTuSdoySVTqlNs1dEoU21QVamMQJxW/Fii5O7g=
+github.com/zeebo/errs v1.2.2/go.mod h1:sgbWHsvVuTPHcqJJGQ1WhI5KbWlHYz+2+2C/LSEtCw4=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a h1:oWX7TPOiFAMXLq8o0ikBYfCJVlRHBcsciT5bXOrH628=
@@ -37,4 +40,6 @@ google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8 h1:Nw54tB0rB7hY/N0
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/grpc v1.22.0 h1:J0UbZOIrCAl+fpTOf8YLs4dJo8L/owV4LYVtAXQoPkw=
 google.golang.org/grpc v1.22.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
+gopkg.in/square/go-jose.v2 v2.4.1 h1:H0TmLt7/KmzlrDOpa1F+zr0Tk90PbJYBfsVUmRLrf9Y=
+gopkg.in/square/go-jose.v2 v2.4.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/spiffe/id.go
+++ b/spiffe/id.go
@@ -226,6 +226,15 @@ func TrustDomainURI(trustDomain string) *url.URL {
 	}
 }
 
+// TrustDomainIDFromID gets the trust domain ID given a SPIFFE ID
+func TrustDomainIDFromID(id string, mode ValidationMode) (string, error) {
+	u, err := ParseID(id, mode)
+	if err != nil {
+		return "", fmt.Errorf("unable to parse SPIFFE ID: %v", err)
+	}
+	return fmt.Sprintf("%s://%s", u.Scheme, u.Host), nil
+}
+
 // getIDsFromCertificate extracts the SPIFFE ID and Trust Domain ID from the
 // URI SAN of the provided certificate. If the certificate has no URI SAN or
 // the SPIFFE ID is malformed, it will return an error.


### PR DESCRIPTION
Add a method to return all x509 certificates from a bundle

Fixes: #41 