### PR TITLE
Updated spiffeid package scaffolding

### DIFF
--- a/v2/federation/example_test.go
+++ b/v2/federation/example_test.go
@@ -13,7 +13,11 @@ import (
 
 func ExampleFetchBundle_webPKI() {
 	endpointURL := "https://example.org:8443/bundle"
-	trustDomain := spiffeid.TrustDomain("example.org")
+	trustDomain, err := spiffeid.TrustDomainFromString("example.org")
+	if err != nil {
+		// TODO: handle error
+	}
+
 	bundle, err := federation.FetchBundle(context.TODO(), trustDomain, endpointURL)
 	if err != nil {
 		// TODO: handle error
@@ -28,8 +32,11 @@ func ExampleFetchBundle_sPIFFEAuth() {
 	// at https://example.org/bundle with the
 	// spiffe://example.org/bundle-server SPIFFE ID.
 	endpointURL := "https://example.org:8443/bundle"
-	trustDomain := spiffeid.TrustDomain("example.org")
-	serverID := spiffeid.Make(trustDomain, "bundle-server")
+	trustDomain, err := spiffeid.TrustDomainFromString("example.org")
+	if err != nil {
+		// TODO: handle error
+	}
+	serverID := trustDomain.NewID("bundle-server")
 
 	bundle, err := spiffebundle.Load(trustDomain, "bundle.json")
 	if err != nil {
@@ -37,7 +44,7 @@ func ExampleFetchBundle_sPIFFEAuth() {
 	}
 
 	bundleSet := spiffebundle.NewSet(bundle)
-	bundleSet.Insert(bundle)
+	bundleSet.Add(bundle)
 
 	updatedBundle, err := federation.FetchBundle(context.TODO(), trustDomain, endpointURL,
 		federation.WithSPIFFEAuth(bundleSet, serverID))
@@ -47,15 +54,18 @@ func ExampleFetchBundle_sPIFFEAuth() {
 
 	// TODO: use bundle, e.g. replace the bundle in the bundle set so it can
 	// be used to fetch the next bundle.
-	bundleSet.Insert(updatedBundle)
+	bundleSet.Add(updatedBundle)
 }
 
 func ExampleWatchBundle_webPKI() {
 	endpointURL := "https://example.org:8443/bundle"
-	trustDomain := spiffeid.TrustDomain("example.org")
+	trustDomain, err := spiffeid.TrustDomainFromString("example.org")
+	if err != nil {
+		// TODO: handle error
+	}
 
 	var watcher federation.BundleWatcher
-	err := federation.WatchBundle(context.TODO(), trustDomain, endpointURL, watcher)
+	err = federation.WatchBundle(context.TODO(), trustDomain, endpointURL, watcher)
 	if err != nil {
 		// TODO: handle error
 	}
@@ -66,8 +76,11 @@ func ExampleWatchBundle_sPIFFEAuth() {
 	// hosted at https://example.org/bundle with the
 	// spiffe://example.org/bundle-server SPIFFE ID.
 	endpointURL := "https://example.org:8443/bundle"
-	trustDomain := spiffeid.TrustDomain("example.org")
-	serverID := spiffeid.Make(trustDomain, "bundle-server")
+	trustDomain, err := spiffeid.TrustDomainFromString("example.org")
+	if err != nil {
+		// TODO: handle error
+	}
+	serverID := trustDomain.NewID("bundle-server")
 
 	bundle, err := spiffebundle.Load(trustDomain, "bundle.json")
 	if err != nil {
@@ -75,7 +88,7 @@ func ExampleWatchBundle_sPIFFEAuth() {
 	}
 
 	bundleSet := spiffebundle.NewSet(bundle)
-	bundleSet.Insert(bundle)
+	bundleSet.Add(bundle)
 
 	// TODO: When implementing the watcher's OnUpdate, replace the bundle for
 	// the trust domain in the bundle set so the next connection uses the
@@ -90,7 +103,10 @@ func ExampleWatchBundle_sPIFFEAuth() {
 }
 
 func ExampleHandler_webPKI() {
-	trustDomain := spiffeid.TrustDomain("example.org")
+	trustDomain, err := spiffeid.TrustDomainFromString("example.org")
+	if err != nil {
+		// TODO: handle error
+	}
 
 	bundleSource, err := workloadapi.NewBundleSource(context.TODO())
 	if err != nil {
@@ -106,7 +122,10 @@ func ExampleHandler_webPKI() {
 }
 
 func ExampleHandler_sPIFFEAuth() {
-	trustDomain := spiffeid.TrustDomain("example.org")
+	trustDomain, err := spiffeid.TrustDomainFromString("example.org")
+	if err != nil {
+		// TODO: handle error
+	}
 
 	// Create an X.509 source for obtaining the server X509-SVID
 	x509Source, err := workloadapi.NewX509Source(context.TODO())

--- a/v2/logger/writer.go
+++ b/v2/logger/writer.go
@@ -16,20 +16,20 @@ type writer struct {
 
 // Debugf outputs debug logging
 func (w writer) Debugf(format string, args ...interface{}) {
-	fmt.Fprintf(w.Writer, "[DEBUG]: "+format, args...)
+	fmt.Fprintf(w.Writer, "[DEBUG]: "+format+"\n", args...)
 }
 
 // Infof outputs info logging
 func (w writer) Infof(format string, args ...interface{}) {
-	fmt.Fprintf(w.Writer, "[INFO]: "+format, args...)
+	fmt.Fprintf(w.Writer, "[INFO]: "+format+"\n", args...)
 }
 
 // Warnf outputs warn logging
 func (w writer) Warnf(format string, args ...interface{}) {
-	fmt.Fprintf(w.Writer, "[WARN]: "+format, args...)
+	fmt.Fprintf(w.Writer, "[WARN]: "+format+"\n", args...)
 }
 
 // Errorf outputs error logging
 func (w writer) Errorf(format string, args ...interface{}) {
-	fmt.Fprintf(w.Writer, "[ERROR]: "+format, args...)
+	fmt.Fprintf(w.Writer, "[ERROR]: "+format+"\n", args...)
 }

--- a/v2/spiffeid/id.go
+++ b/v2/spiffeid/id.go
@@ -16,20 +16,20 @@ func New(trustDomain string, segments ...string) (ID, error) {
 }
 
 // Must creates a new ID using the trust domain (e.g. example.org) and path
-// segments. The function panics if the trust domain is not value (see
+// segments. The function panics if the trust domain is not valid (see
 // ParseTrustDomain).
 func Must(trustDomain string, segments ...string) ID {
 	panic("not implemented")
 }
 
-// Join returns the string representation of an ID inside the given the trust
+// Join returns the string representation of an ID inside the given trust
 // domain (e.g. example.org) with the given path segments. An error is returned
 // if the trust domain is not valid (see ParseTrustDomain).
 func Join(trustDomain string, segments ...string) (string, error) {
 	panic("not implemented")
 }
 
-// MustJoin returns the string representation of an ID inside the given the trust
+// MustJoin returns the string representation of an ID inside the given trust
 // domain (e.g. example.org) with the given path segments. The function panics
 // if the trust domain is not valid (see ParseTrustDomain).
 func MustJoin(trustDomain string, segments ...string) string {

--- a/v2/spiffeid/id.go
+++ b/v2/spiffeid/id.go
@@ -2,79 +2,77 @@ package spiffeid
 
 import (
 	"net/url"
-	"path"
 )
 
 // ID is a SPIFFE ID
 type ID struct {
-	td   TrustDomain
-	path string
 }
 
-// String returns the string representation of a SPIFFE ID given the trust
-// domain and path segments. For example, String("example.org", "foo", "bar")
-// returns "spiffe://example.org/foo/bar".
-func String(td TrustDomain, segments ...string) string {
-	return Make(td, segments...).String()
-}
-
-// Make makes a SPIFFE ID with the given trust domain and path segments.
-func Make(td TrustDomain, segments ...string) ID {
-	path := path.Join(segments...)
-	if len(path) > 0 && path[0] != '/' {
-		path = "/" + path
-	}
-	return ID{
-		td:   normalizeTrustDomain(td),
-		path: path,
-	}
-}
-
-// Parse parses a SPIFFE ID from a string.
-func Parse(s string) (ID, error) {
+// New creates a new ID using the trust domain (e.g. example.org) and path
+// segments. An error is returned if the trust domain is not valid (see
+// ParseTrustDomain).
+func New(trustDomain string, segments ...string) (ID, error) {
 	panic("not implemented")
 }
 
-// ParseURI parses a SPIFFE ID from a URI.
-func ParseURI(u *url.URL) (ID, error) {
+// Must creates a new ID using the trust domain (e.g. example.org) and path
+// segments. The function panics if the trust domain is not value (see
+// ParseTrustDomain).
+func Must(trustDomain string, segments ...string) ID {
+	panic("not implemented")
+}
+
+// Join returns the string representation of an ID inside the given the trust
+// domain (e.g. example.org) with the given path segments. An error is returned
+// if the trust domain is not valid (see ParseTrustDomain).
+func Join(trustDomain string, segments ...string) (string, error) {
+	panic("not implemented")
+}
+
+// MustJoin returns the string representation of an ID inside the given the trust
+// domain (e.g. example.org) with the given path segments. The function panics
+// if the trust domain is not valid (see ParseTrustDomain).
+func MustJoin(trustDomain string, segments ...string) string {
+	panic("not implemented")
+}
+
+// FromString parses a SPIFFE ID from a string.
+func FromString(s string) (ID, error) {
+	panic("not implemented")
+}
+
+// FromURI parses a SPIFFE ID from a URI.
+func FromURI(u *url.URL) (ID, error) {
 	panic("not implemented")
 }
 
 // TrustDomain returns the trust domain of the SPIFFE ID.
 func (id ID) TrustDomain() TrustDomain {
-	return id.td
+	panic("not implemented")
 }
 
 // MemberOf returns true if the SPIFFE ID is a member of the given trust domain.
 func (id ID) MemberOf(td TrustDomain) bool {
-	return id.td == normalizeTrustDomain(td)
+	panic("not implemented")
 }
 
 // Path returns the path of the SPIFFE ID inside the trust domain.
 func (id ID) Path() string {
-	return id.path
+	panic("not implemented")
 }
 
 // String returns the string representation of the SPIFFE ID, e.g.,
 // "spiffe://example.org/foo/bar".
 func (id ID) String() string {
-	if id.Empty() {
-		return ""
-	}
-	return "spiffe://" + string(id.td) + id.path
+	panic("not implemented")
 }
 
 // URL returns a URL for SPIFFE ID.
 func (id ID) URL() *url.URL {
-	return &url.URL{
-		Scheme: "spiffe",
-		Host:   string(id.td),
-		Path:   id.path,
-	}
+	panic("not implemented")
 }
 
 // Empty returns true if the SPIFFE ID is empty.
 func (id ID) Empty() bool {
-	// Don't bother checking the path. An ID isn't valid without a trust domain.
-	return id.td == ""
+	panic("not implemented")
 }

--- a/v2/spiffeid/id.go
+++ b/v2/spiffeid/id.go
@@ -10,28 +10,28 @@ type ID struct {
 
 // New creates a new ID using the trust domain (e.g. example.org) and path
 // segments. An error is returned if the trust domain is not valid (see
-// ParseTrustDomain).
+// TrustDomainFromString).
 func New(trustDomain string, segments ...string) (ID, error) {
 	panic("not implemented")
 }
 
 // Must creates a new ID using the trust domain (e.g. example.org) and path
 // segments. The function panics if the trust domain is not valid (see
-// ParseTrustDomain).
+// TrustDomainFromString).
 func Must(trustDomain string, segments ...string) ID {
 	panic("not implemented")
 }
 
 // Join returns the string representation of an ID inside the given trust
 // domain (e.g. example.org) with the given path segments. An error is returned
-// if the trust domain is not valid (see ParseTrustDomain).
+// if the trust domain is not valid (see TrustDomainFromString).
 func Join(trustDomain string, segments ...string) (string, error) {
 	panic("not implemented")
 }
 
 // MustJoin returns the string representation of an ID inside the given trust
 // domain (e.g. example.org) with the given path segments. The function panics
-// if the trust domain is not valid (see ParseTrustDomain).
+// if the trust domain is not valid (see TrustDomainFromString).
 func MustJoin(trustDomain string, segments ...string) string {
 	panic("not implemented")
 }

--- a/v2/spiffeid/match.go
+++ b/v2/spiffeid/match.go
@@ -38,10 +38,9 @@ func MatchIDs(expected ...ID) Matcher {
 
 // MatchMemberOf matches any SPIFFE ID in the given trust domain.
 func MatchMemberOf(expected TrustDomain) Matcher {
-	expected = normalizeTrustDomain(expected)
 	return Matcher(func(actual ID) error {
-		if td := actual.TrustDomain(); td != expected {
-			return fmt.Errorf("unexpected trust domain %q", td)
+		if !actual.MemberOf(expected) {
+			return fmt.Errorf("unexpected trust domain %q", expected)
 		}
 		return nil
 	})

--- a/v2/spiffeid/match.go
+++ b/v2/spiffeid/match.go
@@ -40,7 +40,7 @@ func MatchIDs(expected ...ID) Matcher {
 func MatchMemberOf(expected TrustDomain) Matcher {
 	return Matcher(func(actual ID) error {
 		if !actual.MemberOf(expected) {
-			return fmt.Errorf("unexpected trust domain %q", expected)
+			return fmt.Errorf("unexpected trust domain %q", actual.TrustDomain())
 		}
 		return nil
 	})

--- a/v2/spiffeid/trustdomain.go
+++ b/v2/spiffeid/trustdomain.go
@@ -25,7 +25,7 @@ func RequireTrustDomainFromString(s string) TrustDomain {
 
 // TrustDomainFromURI returns a new TrustDomain from a URI. The URI must be a
 // valid SPIFFE ID (see FromURI) or an error is returned. The trust domain is
-// extract from the host field and normalized to lower case.
+// extracted from the host field and normalized to lower case.
 func TrustDomainFromURI(uri *url.URL) (TrustDomain, error) {
 	panic("not implemented")
 }
@@ -37,7 +37,7 @@ func RequireTrustDomainFromURI(uri *url.URL) TrustDomain {
 	panic("not implemented")
 }
 
-// String returns the trust domain as a string, e.g. example.org
+// String returns the trust domain as a string, e.g. example.org.
 func (td TrustDomain) String() string {
 	panic("not implemented")
 }

--- a/v2/spiffeid/trustdomain.go
+++ b/v2/spiffeid/trustdomain.go
@@ -1,17 +1,64 @@
 package spiffeid
 
-import "strings"
+import (
+	"net/url"
+)
 
-// TrustDomain is the name of a SPIFFE trust domain (e.g. domain.test).
-type TrustDomain string
-
-// ID returns a SPIFFE ID with the given path segments in the trust domain.
-func (td TrustDomain) ID(segments ...string) ID {
-	return Make(td, segments...)
+// TrustDomain is the name of a SPIFFE trust domain (e.g. example.org).
+type TrustDomain struct {
 }
 
-// normalizeTrustDomain normalizes the trust domain by converting it to
-// lowercase.
-func normalizeTrustDomain(td TrustDomain) TrustDomain {
-	return TrustDomain(strings.ToLower(string(td)))
+// TrustDomainFromString returns a new TrustDomain from a string. The string
+// can either be the host part of a URI authority component (e.g. example.org),
+// or a valid SPIFFE ID URI (e.g. spiffe://example.org), otherwise an error is
+// returned.  The trust domain is normalized to lower case.
+func TrustDomainFromString(s string) (TrustDomain, error) {
+	panic("not implemented")
+}
+
+// RequireTrustDomainFromString is similar to TrustDomainFromString except that
+// instead of returning an error on malformed input, it panics. It should only
+// be used when given string is statically verifiable.
+func RequireTrustDomainFromString(s string) TrustDomain {
+	panic("not implemented")
+}
+
+// TrustDomainFromURI returns a new TrustDomain from a URI. The URI must be a
+// valid SPIFFE ID (see FromURI) or an error is returned. The trust domain is
+// extract from the host field and normalized to lower case.
+func TrustDomainFromURI(uri *url.URL) (TrustDomain, error) {
+	panic("not implemented")
+}
+
+// RequireTrustDomainFromURI is similar to TrustDomainFromURI except that
+// instead of returning an error on malformed input, it panics. It should only
+// be used when the given URI is statically verifiable.
+func RequireTrustDomainFromURI(uri *url.URL) TrustDomain {
+	panic("not implemented")
+}
+
+// String returns the trust domain as a string, e.g. example.org
+func (td TrustDomain) String() string {
+	panic("not implemented")
+}
+
+// ID returns the SPIFFE ID of the trust domain.
+func (td TrustDomain) ID() ID {
+	panic("not implemented")
+}
+
+// ID returns a string representation of the the SPIFFE ID of the trust domain,
+// e.g. "spiffe://example.org".
+func (td TrustDomain) IDString() string {
+	panic("not implemented")
+}
+
+// NewID returns a SPIFFE ID with the given path inside the trust domain.
+func (td TrustDomain) NewID(path string) ID {
+	panic("not implemented")
+}
+
+// Empty returns true if the trust domain value is empty.
+func (td TrustDomain) Empty() bool {
+	panic("not implemented")
 }

--- a/v2/spiffetls/tlsconfig/examples_test.go
+++ b/v2/spiffetls/tlsconfig/examples_test.go
@@ -4,35 +4,46 @@ import (
 	"context"
 
 	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/go-spiffe/v2/spiffetls/tlsconfig"
 	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
 	"github.com/spiffe/go-spiffe/v2/workloadapi"
 )
 
 func ExampleMTLSServerConfig_fileSource() {
+	td, err := spiffeid.TrustDomainFromString("example.org")
+	if err != nil {
+		// TODO: error handling
+	}
+
 	svid, err := x509svid.Load("svid.pem", "key.pem")
 	if err != nil {
 		// TODO: handle error
 	}
 
-	bundle, err := x509bundle.Load("example.org", "cacert.pem")
+	bundle, err := x509bundle.Load(td, "cacert.pem")
 	if err != nil {
 		// TODO: handle error
 	}
 
-	config := tlsconfig.MTLSServerConfig(svid, bundle, tlsconfig.AuthorizeMemberOf("example.org"))
+	config := tlsconfig.MTLSServerConfig(svid, bundle, tlsconfig.AuthorizeMemberOf(td))
 	// TODO: use the config
 	config = config
 }
 
 func ExampleMTLSServerConfig_workloadAPISource() {
+	td, err := spiffeid.TrustDomainFromString("example.org")
+	if err != nil {
+		// TODO: error handling
+	}
+
 	source, err := workloadapi.NewX509Source(context.Background())
 	if err != nil {
 		// TODO: handle error
 	}
 	defer source.Close()
 
-	config := tlsconfig.MTLSServerConfig(source, source, tlsconfig.AuthorizeMemberOf("example.org"))
+	config := tlsconfig.MTLSServerConfig(source, source, tlsconfig.AuthorizeMemberOf(td))
 	// TODO: use the config
 	config = config
 }

--- a/v2/svid/jwtsvid/examples_test.go
+++ b/v2/svid/jwtsvid/examples_test.go
@@ -9,9 +9,13 @@ import (
 )
 
 func ExampleParseAndValidate() {
+	td, err := spiffeid.TrustDomainFromString("example.org")
+	if err != nil {
+		// TODO: error handling
+	}
+
 	token := "TODO"
-	audience := []string{spiffeid.String("example.org", "server")}
-	authorizer := jwtsvid.AuthorizeID(spiffeid.Make("example.org", "client"))
+	audience := []string{td.NewID("server").String()}
 
 	jwtSource, err := workloadapi.NewJWTSource(context.TODO())
 	if err != nil {
@@ -19,32 +23,7 @@ func ExampleParseAndValidate() {
 	}
 	defer jwtSource.Close()
 
-	svid, err := jwtsvid.ParseAndValidate(token, jwtSource, audience, authorizer)
-	if err != nil {
-		// TODO: error handling
-	}
-
-	// TODO: do something with the JWT-SVID
-	svid = svid
-}
-
-func ExampleParseAndValidate_customAuthorization() {
-	token := "TODO"
-	serverID := spiffeid.Make("example.org", "server")
-	audience := []string{serverID.String()}
-
-	authorizer := func(id spiffeid.ID, claims map[string]interface{}) error {
-		// TODO: perform custom authorization on the ID and token claims
-		return nil
-	}
-
-	jwtSource, err := workloadapi.NewJWTSource(context.TODO())
-	if err != nil {
-		// TODO: error handling
-	}
-	defer jwtSource.Close()
-
-	svid, err := jwtsvid.ParseAndValidate(token, jwtSource, audience, authorizer)
+	svid, err := jwtsvid.ParseAndValidate(token, jwtSource, audience)
 	if err != nil {
 		// TODO: error handling
 	}

--- a/v2/workloadapi/examples_test.go
+++ b/v2/workloadapi/examples_test.go
@@ -19,8 +19,13 @@ func ExampleFetchX509SVID() {
 }
 
 func ExampleFetchJWTSVID() {
+	serverID, err := spiffeid.Join("example.org", "server")
+	if err != nil {
+		// TODO: error handling
+	}
+
 	svid, err := workloadapi.FetchJWTSVID(context.TODO(), jwtsvid.Params{
-		Audience: spiffeid.String("example.org", "server"),
+		Audience: serverID,
 	})
 	if err != nil {
 		// TODO: error handling
@@ -31,8 +36,13 @@ func ExampleFetchJWTSVID() {
 }
 
 func ExampleValidateJWTSVID() {
+	serverID, err := spiffeid.Join("example.org", "server")
+	if err != nil {
+		// TODO: error handling
+	}
+
 	token := "TODO"
-	svid, err := workloadapi.ValidateJWTSVID(context.TODO(), token, spiffeid.String("example.org", "server"))
+	svid, err := workloadapi.ValidateJWTSVID(context.TODO(), token, serverID)
 	if err != nil {
 		// TODO: error handling
 	}


### PR DESCRIPTION
Converted the TrustDomain type to a strongly validated struct type with forced
normalization. Provided methods to get a TrustDomain from string and
URI with "Require*" variants that panic instead of returning an error
for convenient use with verifiable constants.

Also renamed some of the ID methods to match trust domain equivalents
for consistency.

Also:
- Fixed up writer-based logger to add newlines
- Fixed up broken examples
- Removed presumed implementation details in the ID type to allow for
implementation flexibility

Signed-off-by: Andrew Harding <azdagron@gmail.com>