### PR TITLE
Fix comment consistency and bundle method parity

### DIFF
--- a/v2/bundle/jwtbundle/bundle.go
+++ b/v2/bundle/jwtbundle/bundle.go
@@ -32,7 +32,7 @@ func New(trustDomain spiffeid.TrustDomain) *Bundle {
 	}
 }
 
-// Load loads a Bundle from a file on disk.
+// Load loads a bundle from a file on disk.
 func Load(trustDomain spiffeid.TrustDomain, path string) (*Bundle, error) {
 	bundleBytes, err := ioutil.ReadFile(path)
 	if err != nil {
@@ -69,7 +69,7 @@ func Parse(trustDomain spiffeid.TrustDomain, bundleBytes []byte) (*Bundle, error
 	return bundle, nil
 }
 
-// TrustDomain returns the trust domain the bundle belongs to.
+// TrustDomain returns the trust domain that the bundle belongs to.
 func (b *Bundle) TrustDomain() spiffeid.TrustDomain {
 	return b.trustDomain
 }
@@ -143,9 +143,9 @@ func (b *Bundle) Marshal() ([]byte, error) {
 	return json.Marshal(jwks)
 }
 
-// GetJWTBundleForTrustDomain returns the JWT bundle of the given trust domain.
-// It implements the Source interface. It will fail if called with a trust
-// domain other than the one the bundle belongs to.
+// GetJWTBundleForTrustDomain returns the JWT bundle for the given trust
+// domain. It implements the Source interface. An error will be returned if
+// the trust domain does not match that of the bundle.
 func (b *Bundle) GetJWTBundleForTrustDomain(trustDomain spiffeid.TrustDomain) (*Bundle, error) {
 	b.mtx.RLock()
 	defer b.mtx.RUnlock()

--- a/v2/bundle/jwtbundle/set.go
+++ b/v2/bundle/jwtbundle/set.go
@@ -12,7 +12,7 @@ type Set struct {
 	bundles map[spiffeid.TrustDomain]*Bundle
 }
 
-// NewSet creates a new set initialized with the given bundles
+// NewSet creates a new set initialized with the given bundles.
 func NewSet(bundles ...*Bundle) *Set {
 	bundlesMap := make(map[spiffeid.TrustDomain]*Bundle)
 
@@ -55,8 +55,8 @@ func (s *Set) Has(trustDomain spiffeid.TrustDomain) bool {
 	return ok
 }
 
-// GetJWTBundleForTrustDomain returns the JWT bundle of the given trust domain.
-// It implements the Source interface.
+// GetJWTBundleForTrustDomain returns the JWT bundle for the given trust
+// domain. It implements the Source interface.
 func (s *Set) GetJWTBundleForTrustDomain(trustDomain spiffeid.TrustDomain) (*Bundle, error) {
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()

--- a/v2/bundle/spiffebundle/bundle.go
+++ b/v2/bundle/spiffebundle/bundle.go
@@ -18,12 +18,12 @@ import (
 type Bundle struct {
 }
 
-// New creates a new bundle
+// New creates a new bundle.
 func New(trustDomain spiffeid.TrustDomain) *Bundle {
 	panic("not implemented")
 }
 
-// Load loads a Bundle from a file on disk.
+// Load loads a bundle from a file on disk.
 func Load(trustDomain spiffeid.TrustDomain, path string) (*Bundle, error) {
 	panic("not implemented")
 }
@@ -38,17 +38,17 @@ func Parse(trustDomain spiffeid.TrustDomain, b []byte) (*Bundle, error) {
 	panic("not implemented")
 }
 
-// FromX509Bundle creates a Bundle from an X.509 bundle.
+// FromX509Bundle creates a bundle from an X.509 bundle.
 func FromX509Bundle(x509Bundle *x509bundle.Bundle) *Bundle {
 	panic("not implemented")
 }
 
-// FromJWTBundle creates a Bundle from a JWT bundle.
+// FromJWTBundle creates a bundle from a JWT bundle.
 func FromJWTBundle(jwtBundle *jwtbundle.Bundle) *Bundle {
 	panic("not implemented")
 }
 
-// TrustDomain returns the trust domain of the bundle.
+// TrustDomain returns the trust domain that the bundle belongs to.
 func (b *Bundle) TrustDomain() spiffeid.TrustDomain {
 	panic("not implemented")
 }
@@ -64,12 +64,12 @@ func (b *Bundle) AddX509Root(*x509.Certificate) {
 	panic("not implemented")
 }
 
-// RemoveX509Root removes an X.509 root to the bundle.
+// RemoveX509Root removes an X.509 root from the bundle.
 func (b *Bundle) RemoveX509Root(*x509.Certificate) {
 	panic("not implemented")
 }
 
-// HasX509Root checks if the given X.509 root exists in the bundle
+// HasX509Root checks if the given X.509 root exists in the bundle.
 func (b *Bundle) HasX509Root(root *x509.Certificate) bool {
 	panic("not implemented")
 }
@@ -86,9 +86,14 @@ func (b *Bundle) FindJWTKey(keyID string) (crypto.PublicKey, bool) {
 	panic("not implemented")
 }
 
+// HasJWTKey returns true if the bundle has a JWT key with the given key id.
+func (b *Bundle) HasJWTKey(keyID string) bool {
+	panic("not implemented")
+}
+
 // AddJWTKey adds a JWT key to the bundle. If a JWT key already exists
-// under the given key ID, it is replaced.
-func (b *Bundle) AddJWTKey(keyID string, key crypto.PublicKey) {
+// under the given key ID, it is replaced. A key ID must be specified.
+func (b *Bundle) AddJWTKey(keyID string, key crypto.PublicKey) error {
 	panic("not implemented")
 }
 
@@ -157,16 +162,16 @@ func (b *Bundle) GetBundleForTrustDomain(trustDomain spiffeid.TrustDomain) (*Bun
 	panic("not implemented")
 }
 
-// GetX509BundleForTrustDomain implements the x509bundle.Source interface. An
-// error will be returned if the trust domain does not match that of the
-// bundle.
+// GetX509BundleForTrustDomain returns the X.509 bundle for the given trust
+// domain. It implements the x509bundle.Source interface. An error will be
+// returned if the trust domain does not match that of the bundle.
 func (b *Bundle) GetX509BundleForTrustDomain(trustDomain spiffeid.TrustDomain) (*x509bundle.Bundle, error) {
 	panic("not implemented")
 }
 
-// GetJWTBundleForTrustDomain implements the jwtbundle.Source interface. An
-// error will be returned if the trust domain does not match that of the
-// bundle.
+// GetJWTBundleForTrustDomain returns the JWT bundle of the given trust domain.
+// It implements the jwtbundle.Source interface. An error will be returned if
+// the trust domain does not match that of the bundle.
 func (b *Bundle) GetJWTBundleForTrustDomain(trustDomain spiffeid.TrustDomain) (*jwtbundle.Bundle, error) {
 	panic("not implemented")
 }

--- a/v2/bundle/spiffebundle/set.go
+++ b/v2/bundle/spiffebundle/set.go
@@ -9,7 +9,7 @@ import (
 // Set is a set of bundles, keyed by trust domain.
 type Set struct{}
 
-// NewSet creates a new, empty set.
+// NewSet creates a new set initialized with the given bundles.
 func NewSet(bundles ...*Bundle) *Set {
 	panic("not implemented")
 }

--- a/v2/bundle/x509bundle/bundle.go
+++ b/v2/bundle/x509bundle/bundle.go
@@ -16,7 +16,7 @@ const certType string = "CERTIFICATE"
 
 var x509bundleErr = errs.Class("x509bundle")
 
-// Bundle is a collection of trusted public key material for a trust domain.
+// Bundle is a collection of trusted X.509 roots for a trust domain.
 type Bundle struct {
 	trustDomain spiffeid.TrustDomain
 
@@ -24,14 +24,14 @@ type Bundle struct {
 	roots    []*x509.Certificate
 }
 
-// New creates a new bundle
+// New creates a new bundle.
 func New(trustDomain spiffeid.TrustDomain) *Bundle {
 	return &Bundle{
 		trustDomain: trustDomain,
 	}
 }
 
-// Load loads a Bundle from a file on disk.
+// Load loads a bundle from a file on disk.
 func Load(trustDomain spiffeid.TrustDomain, path string) (*Bundle, error) {
 	fileBytes, err := ioutil.ReadFile(path)
 	if err != nil {
@@ -77,7 +77,7 @@ func Parse(trustDomain spiffeid.TrustDomain, b []byte) (*Bundle, error) {
 	return bundle, nil
 }
 
-// TrustDomain returns the trust domain of the bundle.
+// TrustDomain returns the trust domain that the bundle belongs to.
 func (b *Bundle) TrustDomain() spiffeid.TrustDomain {
 	return b.trustDomain
 }
@@ -104,7 +104,7 @@ func (b *Bundle) AddX509Root(root *x509.Certificate) {
 	b.roots = append(b.roots, root)
 }
 
-// RemoveX509Root removes an X.509 root to the bundle.
+// RemoveX509Root removes an X.509 root from the bundle.
 func (b *Bundle) RemoveX509Root(root *x509.Certificate) {
 	b.rootsMtx.Lock()
 	defer b.rootsMtx.Unlock()
@@ -118,7 +118,7 @@ func (b *Bundle) RemoveX509Root(root *x509.Certificate) {
 	}
 }
 
-// HasX509Root checks if the given X.509 root exists in the bundle
+// HasX509Root checks if the given X.509 root exists in the bundle.
 func (b *Bundle) HasX509Root(root *x509.Certificate) bool {
 	b.rootsMtx.RLock()
 	defer b.rootsMtx.RUnlock()
@@ -151,8 +151,8 @@ func (b *Bundle) Marshal() ([]byte, error) {
 }
 
 // GetX509BundleForTrustDomain returns the X.509 bundle for the given trust
-// domain. It implements the Source interface. It will fail if
-// called with a trust domain other than the one the bundle belongs to.
+// domain. It implements the Source interface. An error will be
+// returned if the trust domain does not match that of the bundle.
 func (b *Bundle) GetX509BundleForTrustDomain(trustDomain spiffeid.TrustDomain) (*Bundle, error) {
 	if b.trustDomain != trustDomain {
 		return nil, x509bundleErr.New("no X.509 bundle found for trust domain: %q", trustDomain)

--- a/v2/bundle/x509bundle/set.go
+++ b/v2/bundle/x509bundle/set.go
@@ -12,7 +12,7 @@ type Set struct {
 	bundles map[spiffeid.TrustDomain]*Bundle
 }
 
-// NewSet creates a new set initialized with the given bundles
+// NewSet creates a new set initialized with the given bundles.
 func NewSet(bundles ...*Bundle) *Set {
 	bundlesMap := make(map[spiffeid.TrustDomain]*Bundle)
 
@@ -27,7 +27,7 @@ func NewSet(bundles ...*Bundle) *Set {
 	}
 }
 
-// Add add a new bundle into the set. If a bundle already exists for the
+// Add adds a new bundle into the set. If a bundle already exists for the
 // trust domain, the existing bundle is replaced.
 func (s *Set) Add(bundle *Bundle) {
 	s.mtx.Lock()
@@ -38,7 +38,7 @@ func (s *Set) Add(bundle *Bundle) {
 	}
 }
 
-// Remove removes the bundle given by the trust domain.
+// Remove removes the bundle for the given trust domain.
 func (s *Set) Remove(trustDomain spiffeid.TrustDomain) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()


### PR DESCRIPTION
Fixes up comments on bundle methods to be consistent.

Also brings some methods added during the JWT and X.509 bundle development into the SPIFFE bundle scaffolding.