### PR TITLE
Add spiffeid package missing unit tests

### DIFF
--- a/v2/spiffeid/id.go
+++ b/v2/spiffeid/id.go
@@ -26,14 +26,9 @@ func New(trustDomain string, segments ...string) (ID, error) {
 		return ID{}, err
 	}
 
-	path := path.Join(segments...)
-	if len(path) > 0 && path[0] != '/' {
-		path = "/" + path
-	}
-
 	return ID{
 		td:   td,
-		path: path,
+		path: normalizePath(path.Join(segments...)),
 	}, nil
 }
 
@@ -156,4 +151,12 @@ func (id ID) Empty() bool {
 
 func normalizeTrustDomain(td string) string {
 	return strings.ToLower(td)
+}
+
+func normalizePath(path string) string {
+	if len(path) > 0 && path[0] != '/' {
+		return "/" + path
+	}
+
+	return path
 }

--- a/v2/spiffeid/id_test.go
+++ b/v2/spiffeid/id_test.go
@@ -237,11 +237,6 @@ func TestFromString(t *testing.T) {
 }
 
 func TestFromURI(t *testing.T) {
-	parse := func(id string) *url.URL {
-		u, err := url.Parse(id)
-		assert.NoError(t, err)
-		return u
-	}
 	tests := []struct {
 		name          string
 		input         *url.URL
@@ -250,7 +245,7 @@ func TestFromURI(t *testing.T) {
 	}{
 		{
 			name:       "happy_path",
-			input:      parse("spiffe://domain.test/path/element"),
+			input:      parseURI(t, "spiffe://domain.test/path/element"),
 			expectedId: spiffeid.Must("domain.test", "path", "element"),
 		},
 		{
@@ -270,57 +265,57 @@ func TestFromURI(t *testing.T) {
 		},
 		{
 			name:          "invalid_scheme",
-			input:         parse("http://domain.test/path/element"),
+			input:         parseURI(t, "http://domain.test/path/element"),
 			expectedError: "spiffeid: invalid scheme",
 		},
 		{
 			name:       "scheme_mixed_case",
-			input:      parse("SPIFFE://domain.test/path/element"),
+			input:      parseURI(t, "SPIFFE://domain.test/path/element"),
 			expectedId: spiffeid.Must("domain.test", "path", "element"),
 		},
 		{
 			name:          "empty_host",
-			input:         parse("spiffe:///path/element"),
+			input:         parseURI(t, "spiffe:///path/element"),
 			expectedError: "spiffeid: trust domain is empty",
 		},
 		{
 			name:          "empty_port",
-			input:         parse("spiffe://domain.test:/path/element"),
+			input:         parseURI(t, "spiffe://domain.test:/path/element"),
 			expectedError: "spiffeid: colon is not allowed in trust domain",
 		},
 		{
 			name:          "query_not_allowed",
-			input:         parse("spiffe://domain.test/path/element?query=1"),
+			input:         parseURI(t, "spiffe://domain.test/path/element?query=1"),
 			expectedError: "spiffeid: query is not allowed",
 		},
 		{
 			name:          "fragment_not_allowed",
-			input:         parse("spiffe://domain.test/path/element?#fragment-1"),
+			input:         parseURI(t, "spiffe://domain.test/path/element?#fragment-1"),
 			expectedError: "spiffeid: fragment is not allowed",
 		},
 		{
 			name:          "port_not_allowed",
-			input:         parse("spiffe://domain.test:8080/path/element"),
+			input:         parseURI(t, "spiffe://domain.test:8080/path/element"),
 			expectedError: "spiffeid: port is not allowed",
 		},
 		{
 			name:          "user_info_not_allowed",
-			input:         parse("spiffe://user:password@test.org/path/element"),
+			input:         parseURI(t, "spiffe://user:password@test.org/path/element"),
 			expectedError: "spiffeid: user info is not allowed",
 		},
 		{
 			name:       "empty_path",
-			input:      parse("spiffe://domain.test"),
+			input:      parseURI(t, "spiffe://domain.test"),
 			expectedId: spiffeid.Must("domain.test"),
 		},
 		{
 			name:          "missing_double_slash_1",
-			input:         parse("spiffe:path/element"),
+			input:         parseURI(t, "spiffe:path/element"),
 			expectedError: "spiffeid: trust domain is empty",
 		},
 		{
 			name:          "missing_double_slash_2",
-			input:         parse("spiffe:/path/element"),
+			input:         parseURI(t, "spiffe:/path/element"),
 			expectedError: "spiffeid: trust domain is empty",
 		},
 	}
@@ -455,4 +450,10 @@ func TestIDURL(t *testing.T) {
 
 func TestIDEmpty(t *testing.T) {
 	assert.True(t, spiffeid.ID{}.Empty())
+}
+
+func parseURI(t *testing.T, id string) *url.URL {
+	u, err := url.Parse(id)
+	assert.NoError(t, err)
+	return u
 }

--- a/v2/spiffeid/match.go
+++ b/v2/spiffeid/match.go
@@ -22,8 +22,8 @@ func MatchID(expected ID) Matcher {
 	})
 }
 
-// MatchIDs matches any SPIFFE ID in the given list of IDs.
-func MatchIDs(expected ...ID) Matcher {
+// MatchOneOf matches any SPIFFE ID in the given list of IDs.
+func MatchOneOf(expected ...ID) Matcher {
 	set := make(map[ID]struct{})
 	for _, id := range expected {
 		set[id] = struct{}{}

--- a/v2/spiffeid/match_test.go
+++ b/v2/spiffeid/match_test.go
@@ -1,0 +1,83 @@
+package spiffeid_test
+
+import (
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatchAny(t *testing.T) {
+	matcher := spiffeid.MatchAny()
+	assert.NoError(t, matcher(spiffeid.ID{}))
+	assert.NoError(t, matcher(spiffeid.Must("domain.test", "path", "element")))
+	assert.NoError(t, matcher(spiffeid.Must("domain.test")))
+}
+
+func TestMatchID_AgainstIDWithPath(t *testing.T) {
+	matcher := spiffeid.MatchID(spiffeid.Must("domain.test", "path", "element"))
+
+	// Common case
+	err := matcher(spiffeid.Must("domain.test", "path", "element"))
+	assert.NoError(t, err)
+
+	// Different paths
+	err = matcher(spiffeid.Must("domain.test", "path"))
+	assert.EqualError(t, err, "unexpected ID \"spiffe://domain.test/path\"")
+
+	// ID has empty path
+	err = matcher(spiffeid.Must("domain.test"))
+	assert.EqualError(t, err, "unexpected ID \"spiffe://domain.test\"")
+
+	// Empty ID
+	err = matcher(spiffeid.ID{})
+	assert.EqualError(t, err, "unexpected ID \"\"")
+}
+
+func TestMatchID_AgainstIDWithoutPath(t *testing.T) {
+	matcher := spiffeid.MatchID(spiffeid.Must("domain.test"))
+
+	// With path
+	err := matcher(spiffeid.Must("domain.test", "path", "element"))
+	assert.EqualError(t, err, "unexpected ID \"spiffe://domain.test/path/element\"")
+
+	// Without path
+	err = matcher(spiffeid.Must("domain.test"))
+	assert.NoError(t, err)
+}
+
+func TestMatchIDs_OnAListOfIDs(t *testing.T) {
+	matcher := spiffeid.MatchIDs(
+		spiffeid.Must("domain.test"),
+		spiffeid.Must("domain.test", "path"),
+		spiffeid.Must("domain.test", "path", "element"),
+		spiffeid.Must("example.org"),
+	)
+	assert.NoError(t, matcher(spiffeid.Must("domain.test")))
+	assert.NoError(t, matcher(spiffeid.Must("example.org")))
+	assert.NoError(t, matcher(spiffeid.Must("domain.test", "path")))
+	assert.NoError(t, matcher(spiffeid.Must("domain.test", "path", "element")))
+	assert.EqualError(t, matcher(spiffeid.Must("domain.test", "element")), "unexpected ID \"spiffe://domain.test/element\"")
+}
+
+func TestMatchIDs_OnAnEmptyListOfIDs(t *testing.T) {
+	matcher := spiffeid.MatchIDs()
+	assert.EqualError(t, matcher(spiffeid.Must("domain.test")), "unexpected ID \"spiffe://domain.test\"")
+	assert.EqualError(t, matcher(spiffeid.ID{}), "unexpected ID \"\"")
+}
+
+func TestMatchMemberOf_AgainstNonEmptyTrustDomain(t *testing.T) {
+	matcher := spiffeid.MatchMemberOf(spiffeid.RequireTrustDomainFromString("domain.test"))
+	assert.NoError(t, matcher(spiffeid.Must("domain.test")))
+	assert.NoError(t, matcher(spiffeid.Must("domain.test", "path", "element")))
+	assert.EqualError(t, matcher(spiffeid.Must("example.org")), "unexpected trust domain \"example.org\"")
+	assert.EqualError(t, matcher(spiffeid.ID{}), "unexpected trust domain \"\"")
+}
+
+func TestMatchMemberOf_AgainstEmptyTrustDomain(t *testing.T) {
+	matcher := spiffeid.MatchMemberOf(spiffeid.TrustDomain{})
+	assert.EqualError(t, matcher(spiffeid.Must("domain.test")), "unexpected trust domain \"domain.test\"")
+	assert.EqualError(t, matcher(spiffeid.Must("domain.test", "path", "element")), "unexpected trust domain \"domain.test\"")
+	assert.EqualError(t, matcher(spiffeid.Must("example.org")), "unexpected trust domain \"example.org\"")
+	assert.NoError(t, matcher(spiffeid.ID{}))
+}

--- a/v2/spiffeid/match_test.go
+++ b/v2/spiffeid/match_test.go
@@ -46,8 +46,8 @@ func TestMatchID_AgainstIDWithoutPath(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestMatchIDs_OnAListOfIDs(t *testing.T) {
-	matcher := spiffeid.MatchIDs(
+func TestMatchOneOf_OnAListOfIDs(t *testing.T) {
+	matcher := spiffeid.MatchOneOf(
 		spiffeid.Must("domain.test"),
 		spiffeid.Must("domain.test", "path"),
 		spiffeid.Must("domain.test", "path", "element"),
@@ -60,8 +60,8 @@ func TestMatchIDs_OnAListOfIDs(t *testing.T) {
 	assert.EqualError(t, matcher(spiffeid.Must("domain.test", "element")), "unexpected ID \"spiffe://domain.test/element\"")
 }
 
-func TestMatchIDs_OnAnEmptyListOfIDs(t *testing.T) {
-	matcher := spiffeid.MatchIDs()
+func TestMatchOneOf_OnAnEmptyListOfIDs(t *testing.T) {
+	matcher := spiffeid.MatchOneOf()
 	assert.EqualError(t, matcher(spiffeid.Must("domain.test")), "unexpected ID \"spiffe://domain.test\"")
 	assert.EqualError(t, matcher(spiffeid.ID{}), "unexpected ID \"\"")
 }

--- a/v2/spiffeid/trustdomain.go
+++ b/v2/spiffeid/trustdomain.go
@@ -84,7 +84,7 @@ func (td TrustDomain) IDString() string {
 func (td TrustDomain) NewID(path string) ID {
 	return ID{
 		td:   td,
-		path: path,
+		path: normalizePath(path),
 	}
 }
 

--- a/v2/spiffeid/trustdomain_test.go
+++ b/v2/spiffeid/trustdomain_test.go
@@ -1,7 +1,6 @@
 package spiffeid_test
 
 import (
-	"fmt"
 	"net/url"
 	"testing"
 
@@ -79,12 +78,9 @@ func TestTrustDomainFromString(t *testing.T) {
 
 func TestRequireTrustDomainFromString(t *testing.T) {
 	// Just test the panic, the non panicing cases are already handled by TestTrustDomainFromString.
-	defer func() {
-		if p := recover(); p != nil {
-			assert.Equal(t, "spiffeid: colon is not allowed in trust domain", fmt.Sprintf("%v", p))
-		}
-	}()
-	spiffeid.RequireTrustDomainFromString("spiffe://domain.test:")
+	assert.PanicsWithError(t, "spiffeid: colon is not allowed in trust domain", func() {
+		spiffeid.RequireTrustDomainFromString("spiffe://domain.test:")
+	})
 }
 
 func TestTrustDomainFromURI(t *testing.T) {
@@ -157,12 +153,9 @@ func TestTrustDomainFromURI(t *testing.T) {
 
 func TestRequireTrustDomainFromURI(t *testing.T) {
 	// Just test the panic, the non panicing cases are already handled by TestTrustDomainFromURI.
-	defer func() {
-		if p := recover(); p != nil {
-			assert.Equal(t, "spiffeid: colon is not allowed in trust domain", fmt.Sprintf("%v", p))
-		}
-	}()
-	spiffeid.RequireTrustDomainFromURI(parseURI(t, "spiffe://domain.test:"))
+	assert.PanicsWithError(t, "spiffeid: colon is not allowed in trust domain", func() {
+		spiffeid.RequireTrustDomainFromURI(parseURI(t, "spiffe://domain.test:"))
+	})
 }
 
 func TestTrustDomainID(t *testing.T) {

--- a/v2/spiffeid/trustdomain_test.go
+++ b/v2/spiffeid/trustdomain_test.go
@@ -1,0 +1,212 @@
+package spiffeid_test
+
+import (
+	"fmt"
+	"net/url"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTrustDomainFromString(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		expectedTd    string
+		expectedError string
+	}{
+		{
+			name:       "has_uppercase_chars",
+			input:      "DomAin.TesT",
+			expectedTd: "domain.test",
+		},
+		{
+			name:       "has_valid_scheme",
+			input:      "spiffe://domain.test",
+			expectedTd: "domain.test",
+		},
+		{
+			name:       "is_valid_spiffe_id",
+			input:      "spiffe://domain.test/path/element",
+			expectedTd: "domain.test",
+		},
+		{
+			name:       "is_valid_spiffe_id_with_spiffe_id_as_path",
+			input:      "spiffe://domain.test/spiffe://domain.test/path/element",
+			expectedTd: "domain.test",
+		},
+		{
+			name:       "is_valid_spiffe_id_with_invalid_spiffe_id_as_path",
+			input:      "spiffe://domain.test/spiffe://domain.test:80/path/element",
+			expectedTd: "domain.test",
+		},
+		{
+			name:          "has_invalid_scheme",
+			input:         "http://domain.test",
+			expectedError: "spiffeid: invalid scheme",
+		},
+		{
+			name:          "missing_scheme",
+			input:         "://domain.test",
+			expectedError: "spiffeid: unable to parse: parse \"://domain.test\": missing protocol scheme",
+		},
+		{
+			name:          "has_port",
+			input:         "spiffe://domain.test:80",
+			expectedError: "spiffeid: port is not allowed",
+		},
+		{
+			name:          "has_colon",
+			input:         "spiffe://domain.test:",
+			expectedError: "spiffeid: colon is not allowed in trust domain",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			td, err := spiffeid.TrustDomainFromString(test.input)
+			if test.expectedError == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, test.expectedError)
+			}
+
+			assert.Equal(t, test.expectedTd, td.String())
+		})
+	}
+}
+
+func TestRequireTrustDomainFromString(t *testing.T) {
+	// Just test the panic, the non panicing cases are already handled by TestTrustDomainFromString.
+	defer func() {
+		if p := recover(); p != nil {
+			assert.Equal(t, "spiffeid: colon is not allowed in trust domain", fmt.Sprintf("%v", p))
+		}
+	}()
+	spiffeid.RequireTrustDomainFromString("spiffe://domain.test:")
+}
+
+func TestTrustDomainFromURI(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         *url.URL
+		expectedTd    string
+		expectedError string
+	}{
+		{
+			name:       "happy_path",
+			input:      parseURI(t, "spiffe://domain.test/path/element"),
+			expectedTd: "domain.test",
+		},
+		{
+			name:       "has_valid_scheme",
+			input:      parseURI(t, "spiffe://domain.test"),
+			expectedTd: "domain.test",
+		},
+		{
+			name:       "is_valid_spiffe_id_with_spiffe_id_as_path",
+			input:      parseURI(t, "spiffe://domain.test/spiffe://example.test/path/element"),
+			expectedTd: "domain.test",
+		},
+		{
+			name:       "is_valid_spiffe_id_with_invalid_spiffe_id_as_path",
+			input:      parseURI(t, "spiffe://domain.test/spiffe://example.test:80/path/element"),
+			expectedTd: "domain.test",
+		},
+		{
+			name:       "has_uppercase_chars",
+			input:      parseURI(t, "spiffe://DomAin.TesT"),
+			expectedTd: "domain.test",
+		},
+		{
+			name:          "has_invalid_scheme",
+			input:         parseURI(t, "http://domain.test"),
+			expectedError: "spiffeid: invalid scheme",
+		},
+		{
+			name:          "missing_scheme",
+			input:         &url.URL{Host: "domain.test"},
+			expectedError: "spiffeid: invalid scheme",
+		},
+		{
+			name:          "has_port",
+			input:         parseURI(t, "spiffe://domain.test:80"),
+			expectedError: "spiffeid: port is not allowed",
+		},
+		{
+			name:          "has_colon",
+			input:         parseURI(t, "spiffe://domain.test:"),
+			expectedError: "spiffeid: colon is not allowed in trust domain",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			td, err := spiffeid.TrustDomainFromURI(test.input)
+			if test.expectedError == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, test.expectedError)
+			}
+
+			assert.Equal(t, test.expectedTd, td.String())
+		})
+	}
+}
+
+func TestRequireTrustDomainFromURI(t *testing.T) {
+	// Just test the panic, the non panicing cases are already handled by TestTrustDomainFromURI.
+	defer func() {
+		if p := recover(); p != nil {
+			assert.Equal(t, "spiffeid: colon is not allowed in trust domain", fmt.Sprintf("%v", p))
+		}
+	}()
+	spiffeid.RequireTrustDomainFromURI(parseURI(t, "spiffe://domain.test:"))
+}
+
+func TestTrustDomainID(t *testing.T) {
+	id := spiffeid.Must("domain.test")
+
+	// Common case
+	td := spiffeid.RequireTrustDomainFromString("spiffe://domain.test/path/element")
+	assert.Equal(t, id, td.ID())
+
+	// Empty path
+	td = spiffeid.RequireTrustDomainFromString("domain.test")
+	assert.Equal(t, id, td.ID())
+}
+
+func TestTrustDomainIDString(t *testing.T) {
+	// Common case
+	td := spiffeid.RequireTrustDomainFromString("spiffe://domain.test/path/element")
+	assert.Equal(t, "spiffe://domain.test", td.IDString())
+
+	// Empty path
+	td = spiffeid.RequireTrustDomainFromString("domain.test")
+	assert.Equal(t, "spiffe://domain.test", td.IDString())
+
+	// With uppercase letters
+	td = spiffeid.RequireTrustDomainFromString("DoMain.TesT")
+	assert.Equal(t, "spiffe://domain.test", td.IDString())
+}
+
+func TestTrustDomainNewID(t *testing.T) {
+	td := spiffeid.RequireTrustDomainFromString("domain.test")
+
+	// Common case
+	id := spiffeid.Must("domain.test", "path", "element")
+	assert.Equal(t, id, td.NewID("/path/element"))
+
+	// Without starting with a slash
+	id = spiffeid.Must("domain.test", "path", "element")
+	assert.Equal(t, id, td.NewID("path/element"))
+
+	// Empty path
+	id = spiffeid.Must("domain.test")
+	assert.Equal(t, id, td.NewID(""))
+}
+
+func TestTrustDomainEmpty(t *testing.T) {
+	assert.True(t, spiffeid.TrustDomain{}.Empty())
+}

--- a/v2/spiffetls/tlsconfig/authorizer.go
+++ b/v2/spiffetls/tlsconfig/authorizer.go
@@ -21,9 +21,9 @@ func AuthorizeID(allowed spiffeid.ID) Authorizer {
 	return AdaptMatcher(spiffeid.MatchID(allowed))
 }
 
-// AuthorizeIDs allows any SPIFFE ID in the given list of IDs.
-func AuthorizeIDs(allowed ...spiffeid.ID) Authorizer {
-	return AdaptMatcher(spiffeid.MatchIDs(allowed...))
+// AuthorizeOneOf allows any SPIFFE ID in the given list of IDs.
+func AuthorizeOneOf(allowed ...spiffeid.ID) Authorizer {
+	return AdaptMatcher(spiffeid.MatchOneOf(allowed...))
 }
 
 // AuthorizeMemberOf allows any SPIFFE ID in the given trust domain.


### PR DESCRIPTION
This PR mainly adds the missing unit tests for spiffeid package. Additionally, it has a fix to spiffeid.NewID function, and the renaming of spiffeid.MatchIDs function.