### PR TITLE
Add x509svid.Verify() unit test

### DIFF
--- a/v2/internal/test/ca.go
+++ b/v2/internal/test/ca.go
@@ -1,0 +1,133 @@
+package test
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"math/big"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/require"
+)
+
+type CA struct {
+	tb     testing.TB
+	parent *CA
+	cert   *x509.Certificate
+	key    crypto.Signer
+}
+
+func NewCA(tb testing.TB) *CA {
+	cert, key := CreateCACertificate(tb, nil, nil)
+	return &CA{
+		tb:   tb,
+		cert: cert,
+		key:  key,
+	}
+}
+
+func (ca *CA) ChildCA() *CA {
+	cert, key := CreateCACertificate(ca.tb, ca.cert, ca.key)
+	return &CA{
+		tb:     ca.tb,
+		parent: ca,
+		cert:   cert,
+		key:    key,
+	}
+}
+
+func (ca *CA) CreateX509SVID(spiffeID string) ([]*x509.Certificate, crypto.Signer) {
+	cert, key := CreateX509SVID(ca.tb, ca.cert, ca.key, spiffeID)
+	return append([]*x509.Certificate{cert}, ca.chain(false)...), key
+}
+
+func (ca *CA) chain(includeRoot bool) []*x509.Certificate {
+	chain := []*x509.Certificate{}
+	next := ca
+	for next != nil {
+		if includeRoot || next.parent != nil {
+			chain = append(chain, next.cert)
+		}
+		next = next.parent
+	}
+	return chain
+}
+
+func (ca *CA) Roots() []*x509.Certificate {
+	root := ca
+	for root.parent != nil {
+		root = root.parent
+	}
+	return []*x509.Certificate{root.cert}
+}
+
+func (ca *CA) Bundle(td spiffeid.TrustDomain) *x509bundle.Bundle {
+	bundle := x509bundle.New(td)
+	for _, root := range ca.Roots() {
+		bundle.AddX509Root(root)
+	}
+	return bundle
+}
+
+func CreateCACertificate(tb testing.TB, parent *x509.Certificate, parentKey crypto.Signer) (*x509.Certificate, crypto.Signer) {
+	now := time.Now()
+	serial := NewSerial(tb)
+
+	key := NewEC256Key(tb)
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName: fmt.Sprintf("CA %x", serial),
+		},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		NotBefore:             now,
+		NotAfter:              now.Add(time.Hour),
+	}
+	if parent == nil {
+		parent = tmpl
+		parentKey = key
+	}
+	return CreateCertificate(tb, tmpl, parent, key.Public(), parentKey), key
+}
+
+func CreateX509SVID(tb testing.TB, parent *x509.Certificate, parentKey crypto.Signer, spiffeID string) (*x509.Certificate, crypto.Signer) {
+	now := time.Now()
+	serial := NewSerial(tb)
+
+	uriSAN, err := url.Parse(spiffeID)
+	require.NoError(tb, err)
+
+	key := NewEC256Key(tb)
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName: fmt.Sprintf("CA %x", serial),
+		},
+		NotBefore: now,
+		NotAfter:  now.Add(time.Hour),
+		URIs:      []*url.URL{uriSAN},
+	}
+	return CreateCertificate(tb, tmpl, parent, key.Public(), parentKey), key
+}
+
+func CreateCertificate(tb testing.TB, tmpl, parent *x509.Certificate, pub, priv interface{}) *x509.Certificate {
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, parent, pub, priv)
+	require.NoError(tb, err)
+	cert, err := x509.ParseCertificate(certDER)
+	require.NoError(tb, err)
+	return cert
+}
+
+func NewSerial(tb testing.TB) *big.Int {
+	b := make([]byte, 8)
+	_, err := rand.Read(b)
+	require.NoError(tb, err)
+	return new(big.Int).SetBytes(b)
+}

--- a/v2/internal/test/ca.go
+++ b/v2/internal/test/ca.go
@@ -47,18 +47,6 @@ func (ca *CA) CreateX509SVID(spiffeID string) ([]*x509.Certificate, crypto.Signe
 	return append([]*x509.Certificate{cert}, ca.chain(false)...), key
 }
 
-func (ca *CA) chain(includeRoot bool) []*x509.Certificate {
-	chain := []*x509.Certificate{}
-	next := ca
-	for next != nil {
-		if includeRoot || next.parent != nil {
-			chain = append(chain, next.cert)
-		}
-		next = next.parent
-	}
-	return chain
-}
-
 func (ca *CA) Roots() []*x509.Certificate {
 	root := ca
 	for root.parent != nil {
@@ -108,7 +96,7 @@ func CreateX509SVID(tb testing.TB, parent *x509.Certificate, parentKey crypto.Si
 	tmpl := &x509.Certificate{
 		SerialNumber: serial,
 		Subject: pkix.Name{
-			CommonName: fmt.Sprintf("CA %x", serial),
+			CommonName: fmt.Sprintf("X509-SVID %x", serial),
 		},
 		NotBefore: now,
 		NotAfter:  now.Add(time.Hour),
@@ -130,4 +118,16 @@ func NewSerial(tb testing.TB) *big.Int {
 	_, err := rand.Read(b)
 	require.NoError(tb, err)
 	return new(big.Int).SetBytes(b)
+}
+
+func (ca *CA) chain(includeRoot bool) []*x509.Certificate {
+	chain := []*x509.Certificate{}
+	next := ca
+	for next != nil {
+		if includeRoot || next.parent != nil {
+			chain = append(chain, next.cert)
+		}
+		next = next.parent
+	}
+	return chain
 }

--- a/v2/internal/test/keys.go
+++ b/v2/internal/test/keys.go
@@ -1,0 +1,20 @@
+package test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Methods to generate private keys. If generation starts slowing down test
+// execution then switch over to pre-generated keys.
+
+// NewEC256Key returns an ECDSA key over the P256 curve
+func NewEC256Key(tb testing.TB) *ecdsa.PrivateKey {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(tb, err)
+	return key
+}

--- a/v2/svid/x509svid/verify_test.go
+++ b/v2/svid/x509svid/verify_test.go
@@ -15,7 +15,7 @@ import (
 func TestVerify(t *testing.T) {
 	ca1 := test.NewCA(t)
 	leaf1, _ := ca1.CreateX509SVID("spiffe://domain1.test/workload")
-	leaf1NoUri := removeURIs(leaf1[0])
+	leaf1NoURI := removeURIs(leaf1[0])
 	leaf1DupUris := dupURIs(leaf1[0])
 	leaf1IsCA := setIsCA(leaf1[0])
 	leaf1WithCertSign := setKeyUsage(leaf1[0], x509.KeyUsageCertSign)
@@ -34,7 +34,7 @@ func TestVerify(t *testing.T) {
 		name       string
 		chain      []*x509.Certificate
 		bundle     x509bundle.Source
-		expectedId spiffeid.ID
+		expectedID spiffeid.ID
 		err        string
 	}{
 		{
@@ -79,7 +79,7 @@ func TestVerify(t *testing.T) {
 		},
 		{
 			name:   "no URI SAN",
-			chain:  leaf1NoUri,
+			chain:  leaf1NoURI,
 			bundle: bundle1,
 			err:    "x509svid: could not get SPIFFE ID: x509svid: leaf certificate contains no URI SAN",
 		},
@@ -116,9 +116,9 @@ func TestVerify(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			_, verifiedChains, err := x509svid.Verify(testCase.chain, testCase.bundle)
-			if testCase.err != "" {
-				require.EqualError(t, err, testCase.err)
+			_, verifiedChains, err := x509svid.Verify(testCase.chain, testCase.bundle) //nolint
+			if testCase.err != "" {                                                    //nolint
+				require.EqualError(t, err, testCase.err) //nolint
 				return
 			}
 			require.NoError(t, err)
@@ -164,6 +164,6 @@ func setIsCA(cert *x509.Certificate) []*x509.Certificate {
 
 func setKeyUsage(cert *x509.Certificate, ku x509.KeyUsage) []*x509.Certificate {
 	c := *cert
-	c.KeyUsage = c.KeyUsage | ku
+	c.KeyUsage |= ku
 	return []*x509.Certificate{&c}
 }

--- a/v2/svid/x509svid/verify_test.go
+++ b/v2/svid/x509svid/verify_test.go
@@ -1,0 +1,169 @@
+package x509svid_test
+
+import (
+	"crypto/x509"
+	"net/url"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
+	"github.com/spiffe/go-spiffe/v2/internal/test"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerify(t *testing.T) {
+	ca1 := test.NewCA(t)
+	leaf1, _ := ca1.CreateX509SVID("spiffe://domain1.test/workload")
+	leaf1NoUri := removeURIs(leaf1[0])
+	leaf1DupUris := dupURIs(leaf1[0])
+	leaf1IsCA := setIsCA(leaf1[0])
+	leaf1WithCertSign := setKeyUsage(leaf1[0], x509.KeyUsageCertSign)
+	leaf1WithCRLSign := setKeyUsage(leaf1[0], x509.KeyUsageCRLSign)
+	bundle1 := ca1.Bundle(spiffeid.RequireTrustDomainFromString("spiffe://domain1.test"))
+
+	ca2 := test.NewCA(t)
+	bundle2 := ca2.Bundle(spiffeid.RequireTrustDomainFromString("spiffe://domain2.test"))
+
+	// bad leaf cert... invalid spiffe ID
+	leafBad, _ := ca1.CreateX509SVID("sparfe://domain1.test/workload")
+	// bad set of roots... sets roots for ca2 under domain1.test
+	bundleBad := ca2.Bundle(spiffeid.RequireTrustDomainFromString("spiffe://domain1.test"))
+
+	testCases := []struct {
+		name       string
+		chain      []*x509.Certificate
+		bundle     x509bundle.Source
+		expectedId spiffeid.ID
+		err        string
+	}{
+		{
+			name:   "empty chain",
+			bundle: bundle1,
+			err:    "x509svid: empty certificates chain",
+		},
+		{
+			name:   "empty bundle",
+			chain:  leaf1,
+			err:    "x509svid: could not get X509 bundle: x509bundle: no X.509 bundle found for trust domain: \"domain1.test\"",
+			bundle: &x509bundle.Bundle{},
+		},
+		{
+			name:  "nil bundle",
+			chain: leaf1,
+			err:   "x509svid: bundleSource is required",
+		},
+		{
+			name:   "no roots",
+			chain:  leaf1,
+			err:    "x509svid: could not verify leaf certificate: x509: certificate signed by unknown authority",
+			bundle: x509bundle.New(spiffeid.RequireTrustDomainFromString("domain1.test")),
+		},
+		{
+			name:   "no roots for leaf cert domain",
+			chain:  leaf1,
+			bundle: bundle2,
+			err:    `x509svid: could not get X509 bundle: x509bundle: no X.509 bundle found for trust domain: "domain1.test"`,
+		},
+		{
+			name:   "bad leaf cert id",
+			chain:  leafBad,
+			bundle: bundle1,
+			err:    "x509svid: could not get SPIFFE ID: spiffeid: invalid scheme",
+		},
+		{
+			name:   "verification fails",
+			chain:  leaf1,
+			bundle: bundleBad,
+			err:    "x509svid: could not verify leaf certificate: x509: certificate signed by unknown authority",
+		},
+		{
+			name:   "no URI SAN",
+			chain:  leaf1NoUri,
+			bundle: bundle1,
+			err:    "x509svid: could not get SPIFFE ID: x509svid: leaf certificate contains no URI SAN",
+		},
+		{
+			name:   "more than one URI SAN",
+			chain:  leaf1DupUris,
+			bundle: bundle1,
+			err:    "x509svid: could not get SPIFFE ID: x509svid: leaf certificate contains more than one URI SAN",
+		},
+		{
+			name:   "leaf is CA",
+			chain:  leaf1IsCA,
+			bundle: bundle1,
+			err:    "x509svid: leaf certificate with CA flag set to true",
+		},
+		{
+			name:   "leaf has KeyUsageCertSign",
+			chain:  leaf1WithCertSign,
+			bundle: bundle1,
+			err:    "x509svid: leaf certificate with KeyCertSign key usage",
+		},
+		{
+			name:   "leaf has KeyUsageCRLSign",
+			chain:  leaf1WithCRLSign,
+			bundle: bundle1,
+			err:    "x509svid: leaf certificate with KeyCrlSign key usage",
+		},
+		{
+			name:   "success",
+			chain:  leaf1,
+			bundle: bundle1,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, verifiedChains, err := x509svid.Verify(testCase.chain, testCase.bundle)
+			if testCase.err != "" {
+				require.EqualError(t, err, testCase.err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, verifiedChains)
+		})
+	}
+}
+
+func TestParseAndVerify(t *testing.T) {
+	ca1 := test.NewCA(t)
+	leaf1, _ := ca1.CreateX509SVID("spiffe://domain1.test/workload")
+	bundle1 := ca1.Bundle(spiffeid.RequireTrustDomainFromString("spiffe://domain1.test"))
+
+	rawLeaf := leaf1[0].Raw
+	_, verifiedChains, err := x509svid.ParseAndVerify([][]byte{rawLeaf}, bundle1)
+	require.NoError(t, err)
+	require.NotNil(t, verifiedChains)
+
+	// We modify some byte to make the parsing fail.
+	rawLeaf[0] = 0x27
+	_, verifiedChains, err = x509svid.ParseAndVerify([][]byte{rawLeaf}, bundle1)
+	require.Contains(t, err.Error(), "x509svid: unable to parse certificate")
+	require.Nil(t, verifiedChains)
+}
+
+func removeURIs(cert *x509.Certificate) []*x509.Certificate {
+	c := *cert
+	c.URIs = []*url.URL{}
+	return []*x509.Certificate{&c}
+}
+
+func dupURIs(cert *x509.Certificate) []*x509.Certificate {
+	c := *cert
+	c.URIs = append(c.URIs, c.URIs...)
+	return []*x509.Certificate{&c}
+}
+
+func setIsCA(cert *x509.Certificate) []*x509.Certificate {
+	c := *cert
+	c.IsCA = true
+	return []*x509.Certificate{&c}
+}
+
+func setKeyUsage(cert *x509.Certificate, ku x509.KeyUsage) []*x509.Certificate {
+	c := *cert
+	c.KeyUsage = c.KeyUsage | ku
+	return []*x509.Certificate{&c}
+}

--- a/v2/svid/x509svid/verify_test.go
+++ b/v2/svid/x509svid/verify_test.go
@@ -162,7 +162,7 @@ func setIsCA(cert *x509.Certificate) []*x509.Certificate {
 	return []*x509.Certificate{&c}
 }
 
-func setKeyUsage(cert *x509.Certificate, ku x509.KeyUsage) []*x509.Certificate {
+func appendKeyUsage(cert *x509.Certificate, ku x509.KeyUsage) []*x509.Certificate {
 	c := *cert
 	c.KeyUsage |= ku
 	return []*x509.Certificate{&c}

--- a/v2/svid/x509svid/verify_test.go
+++ b/v2/svid/x509svid/verify_test.go
@@ -18,8 +18,8 @@ func TestVerify(t *testing.T) {
 	leaf1NoURI := removeURIs(leaf1[0])
 	leaf1DupUris := dupURIs(leaf1[0])
 	leaf1IsCA := setIsCA(leaf1[0])
-	leaf1WithCertSign := setKeyUsage(leaf1[0], x509.KeyUsageCertSign)
-	leaf1WithCRLSign := setKeyUsage(leaf1[0], x509.KeyUsageCRLSign)
+	leaf1WithCertSign := appendKeyUsage(leaf1[0], x509.KeyUsageCertSign)
+	leaf1WithCRLSign := appendKeyUsage(leaf1[0], x509.KeyUsageCRLSign)
 	bundle1 := ca1.Bundle(spiffeid.RequireTrustDomainFromString("spiffe://domain1.test"))
 
 	ca2 := test.NewCA(t)

--- a/v2/svid/x509svid/verify_test.go
+++ b/v2/svid/x509svid/verify_test.go
@@ -115,10 +115,11 @@ func TestVerify(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
+		testCase := testCase // alias loop var as it is used in the closure
 		t.Run(testCase.name, func(t *testing.T) {
-			_, verifiedChains, err := x509svid.Verify(testCase.chain, testCase.bundle) //nolint
-			if testCase.err != "" {                                                    //nolint
-				require.EqualError(t, err, testCase.err) //nolint
+			_, verifiedChains, err := x509svid.Verify(testCase.chain, testCase.bundle)
+			if testCase.err != "" {
+				require.EqualError(t, err, testCase.err)
 				return
 			}
 			require.NoError(t, err)


### PR DESCRIPTION
This PR adds the missing unit test for x509svid.Verify() and x509svid.ParseAndVerify().