### PR TITLE
Copy bundle content containers in and out of bundles

### DIFF
--- a/v2/bundle/jwtbundle/bundle.go
+++ b/v2/bundle/jwtbundle/bundle.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"sync"
 
+	"github.com/spiffe/go-spiffe/v2/internal/jwtutil"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/zeebo/errs"
 	"gopkg.in/square/go-jose.v2"
@@ -36,7 +37,7 @@ func New(trustDomain spiffeid.TrustDomain) *Bundle {
 func FromJWTKeys(trustDomain spiffeid.TrustDomain, jwtKeys map[string]crypto.PublicKey) *Bundle {
 	return &Bundle{
 		trustDomain: trustDomain,
-		jwtKeys:     jwtKeys,
+		jwtKeys:     jwtutil.CopyJWTKeys(jwtKeys),
 	}
 }
 
@@ -87,7 +88,7 @@ func (b *Bundle) JWTKeys() map[string]crypto.PublicKey {
 	b.mtx.RLock()
 	defer b.mtx.RUnlock()
 
-	return b.jwtKeys
+	return jwtutil.CopyJWTKeys(b.jwtKeys)
 }
 
 // FindJWTKey finds the JWT key with the given key id from the bundle. If the key

--- a/v2/bundle/spiffebundle/bundle.go
+++ b/v2/bundle/spiffebundle/bundle.go
@@ -135,7 +135,7 @@ func FromJWTBundle(jwtBundle *jwtbundle.Bundle) *Bundle {
 func FromX509Roots(trustDomain spiffeid.TrustDomain, x509Roots []*x509.Certificate) *Bundle {
 	return &Bundle{
 		trustDomain: trustDomain,
-		x509Roots:   x509Roots,
+		x509Roots:   x509util.CopyX509Roots(x509Roots),
 	}
 }
 
@@ -143,7 +143,7 @@ func FromX509Roots(trustDomain spiffeid.TrustDomain, x509Roots []*x509.Certifica
 func FromJWTKeys(trustDomain spiffeid.TrustDomain, jwtKeys map[string]crypto.PublicKey) *Bundle {
 	return &Bundle{
 		trustDomain: trustDomain,
-		jwtKeys:     jwtKeys,
+		jwtKeys:     jwtutil.CopyJWTKeys(jwtKeys),
 	}
 }
 
@@ -348,7 +348,8 @@ func (b *Bundle) X509Bundle() *x509bundle.Bundle {
 	b.mtx.RLock()
 	defer b.mtx.RUnlock()
 
-	return x509bundle.FromX509Roots(b.trustDomain, x509util.CopyX509Roots(b.x509Roots))
+	// FromX509Roots makes a copy, so we can pass our internal slice directly.
+	return x509bundle.FromX509Roots(b.trustDomain, b.x509Roots)
 }
 
 // JWTBundle returns a JWT bundle containing the JWT keys in the SPIFFE bundle.
@@ -356,7 +357,8 @@ func (b *Bundle) JWTBundle() *jwtbundle.Bundle {
 	b.mtx.RLock()
 	defer b.mtx.RUnlock()
 
-	return jwtbundle.FromJWTKeys(b.trustDomain, jwtutil.CopyJWTKeys(b.jwtKeys))
+	// FromJWTBundle makes a copy, so we can pass our internal slice directly.
+	return jwtbundle.FromJWTKeys(b.trustDomain, b.jwtKeys)
 }
 
 // GetBundleForTrustDomain returns the SPIFFE bundle for the given trust

--- a/v2/bundle/x509bundle/bundle.go
+++ b/v2/bundle/x509bundle/bundle.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/spiffe/go-spiffe/v2/internal/pemutil"
+	"github.com/spiffe/go-spiffe/v2/internal/x509util"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/zeebo/errs"
 )
@@ -32,7 +33,7 @@ func New(trustDomain spiffeid.TrustDomain) *Bundle {
 func FromX509Roots(trustDomain spiffeid.TrustDomain, roots []*x509.Certificate) *Bundle {
 	return &Bundle{
 		trustDomain: trustDomain,
-		roots:       roots,
+		roots:       x509util.CopyX509Roots(roots),
 	}
 }
 
@@ -82,7 +83,7 @@ func (b *Bundle) TrustDomain() spiffeid.TrustDomain {
 func (b *Bundle) X509Roots() []*x509.Certificate {
 	b.rootsMtx.RLock()
 	defer b.rootsMtx.RUnlock()
-	return b.roots
+	return x509util.CopyX509Roots(b.roots)
 }
 
 // AddX509Root adds an X.509 root to the bundle. If the root already


### PR DESCRIPTION
This change updates the bundles to consistently copy the contents
containers holding the bundle contents (X.509 root slices and JWT key
maps) when those content containers go in and out of the bundle. This is
only a shallow copy of the data structure for the contents, not a deep
copy of the contents themselves.

Specifically, all `From*` methods make a copy of the incoming
containers and the X509Roots and JWTKeys methods return a copy of the
containers.

This prevents accidential aliasing of slice backing arrays and maps.