### PR TITLE
Implement spiffetls dialing

### DIFF
--- a/v2/spiffetls/dial.go
+++ b/v2/spiffetls/dial.go
@@ -41,9 +41,8 @@ func Dial(ctx context.Context, network, addr string, authorizer tlsconfig.Author
 }
 
 // DialWithMode creates a TLS connection using the specified mode.
-func DialWithMode(ctx context.Context, network, addr string, mode DialMode, options ...DialOption) (*Conn, error) {
+func DialWithMode(ctx context.Context, network, addr string, mode DialMode, options ...DialOption) (_ *Conn, err error) {
 	m := mode.get()
-	var err error
 	source := m.source
 	if source == nil {
 		source, err = workloadapi.NewX509Source(ctx, m.options...)
@@ -83,8 +82,7 @@ func DialWithMode(ctx context.Context, network, addr string, mode DialMode, opti
 	case typeMTLSWebClient:
 		tlsconfig.HookMTLSWebClientConfig(tlsConfig, m.svid, m.roots)
 	default:
-		err = spiffetlsErr.New("unknown TLS hook type: %v", m.tlsType)
-		return nil, err
+		return nil, spiffetlsErr.New("unknown TLS auth mode: %v", m.tlsType)
 	}
 
 	var conn *tls.Conn

--- a/v2/spiffetls/dial.go
+++ b/v2/spiffetls/dial.go
@@ -5,18 +5,29 @@ import (
 	"crypto/tls"
 
 	"github.com/spiffe/go-spiffe/v2/spiffetls/tlsconfig"
+	"github.com/spiffe/go-spiffe/v2/workloadapi"
 )
 
 // Conn is a (m)TLS connection backed using materials obtained from the
 // Workload API.
 type Conn struct {
 	*tls.Conn
+	source *workloadapi.X509Source
 }
 
 // Close closes the connection. If the connection has been established using a
 // new X.509 source (the default behavior), that source will also be closed.
 func (c *Conn) Close() error {
-	panic("not implemented")
+	if c.source != nil {
+		c.source.Close()
+	}
+	if c.Conn == nil {
+		return nil
+	}
+	if err := c.Conn.Close(); err != nil {
+		return spiffetlsErr.New("unable to close TLS connection: %w", err)
+	}
+	return nil
 }
 
 // Dial creates an mTLS connection using an X509-SVID obtained from the
@@ -25,10 +36,63 @@ func (c *Conn) Close() error {
 //
 // This is the same as DialWithMode using the MTLSClient mode.
 func Dial(ctx context.Context, network, addr string, authorizer tlsconfig.Authorizer, options ...DialOption) (*Conn, error) {
-	panic("not implemented")
+	return DialWithMode(ctx, network, addr, MTLSClient(authorizer), options...)
 }
 
 // DialWithMode creates a TLS connection using the specified mode.
 func DialWithMode(ctx context.Context, network, addr string, mode DialMode, options ...DialOption) (*Conn, error) {
-	panic("not implemented")
+	m := mode.get()
+	var err error
+	var source *workloadapi.X509Source
+	if m.source != nil {
+		source = m.source
+	} else {
+		source, err = workloadapi.NewX509Source(ctx, m.options...)
+		if err != nil {
+			return nil, spiffetlsErr.New("cannot create X.509 source: %w", err)
+		}
+	}
+
+	if m.bundle == nil {
+		m.bundle = source
+	}
+	if m.svid == nil {
+		m.svid = source
+	}
+
+	opt := &dialOption{}
+	for _, option := range options {
+		option.apply(opt)
+	}
+
+	tlsConfig := &tls.Config{}
+	if opt.baseTLSConf != nil {
+		tlsConfig = opt.baseTLSConf
+	}
+
+	switch m.tlsType {
+	case typeTLSClient:
+		tlsconfig.HookTLSClientConfig(tlsConfig, m.bundle, m.authorizer)
+	case typeMTLSClient:
+		tlsconfig.HookMTLSClientConfig(tlsConfig, m.svid, m.bundle, m.authorizer)
+	case typeMTLSWebClient:
+		tlsconfig.HookMTLSWebClientConfig(tlsConfig, m.svid, m.roots)
+	default:
+		return nil, spiffetlsErr.New("unknown TLS hook type: %v", m.tlsType)
+	}
+
+	var conn *tls.Conn
+	if opt.dialer != nil {
+		conn, err = tls.DialWithDialer(opt.dialer, network, addr, tlsConfig)
+	} else {
+		conn, err = tls.Dial(network, addr, tlsConfig)
+	}
+	if err != nil {
+		return nil, spiffetlsErr.New("unable to dial: %w", err)
+	}
+
+	return &Conn{
+		Conn:   conn,
+		source: m.source,
+	}, nil
 }

--- a/v2/spiffetls/dial.go
+++ b/v2/spiffetls/dial.go
@@ -44,7 +44,7 @@ func Dial(ctx context.Context, network, addr string, authorizer tlsconfig.Author
 func DialWithMode(ctx context.Context, network, addr string, mode DialMode, options ...DialOption) (*Conn, error) {
 	m := mode.get()
 	var err error
-	source := *m.source
+	source := m.source
 	if source == nil {
 		source, err = workloadapi.NewX509Source(ctx, m.options...)
 		// Close source if there is a failiure after this point

--- a/v2/spiffetls/mode.go
+++ b/v2/spiffetls/mode.go
@@ -10,10 +10,10 @@ import (
 	"github.com/spiffe/go-spiffe/v2/workloadapi"
 )
 
-type tlsHookType int
+type authMode int
 
 const (
-	typeTLSClient tlsHookType = iota
+	typeTLSClient authMode = iota
 	typeMTLSClient
 	typeMTLSWebClient
 )
@@ -24,7 +24,7 @@ type DialMode interface {
 }
 
 type dialMode struct {
-	tlsType    tlsHookType
+	tlsType    authMode
 	authorizer tlsconfig.Authorizer
 
 	source  *workloadapi.X509Source

--- a/v2/spiffetls/mode.go
+++ b/v2/spiffetls/mode.go
@@ -10,15 +10,44 @@ import (
 	"github.com/spiffe/go-spiffe/v2/workloadapi"
 )
 
+type tlsHookType int
+
+const (
+	typeTLSClient tlsHookType = iota
+	typeMTLSClient
+	typeMTLSWebClient
+)
+
 // DialMode is a SPIFFE TLS dialing mode.
 type DialMode interface {
+	get() *dialMode
+}
+
+type dialMode struct {
+	tlsType    tlsHookType
+	authorizer tlsconfig.Authorizer
+
+	source  *workloadapi.X509Source
+	options []workloadapi.X509SourceOption
+
+	bundle x509bundle.Source
+	svid   x509svid.Source
+
+	roots *x509.CertPool
+}
+
+func (d *dialMode) get() *dialMode {
+	return d
 }
 
 // TLSClient configures the dialing for TLS. The server X509-SVID is
 // authenticated using X.509 bundles obtained via the Workload API. The
 // authorizer is used to authorize the server X509-SVID.
 func TLSClient(authorizer tlsconfig.Authorizer) DialMode {
-	panic("not implemented")
+	return &dialMode{
+		tlsType:    typeTLSClient,
+		authorizer: authorizer,
+	}
 }
 
 // TLSClientWithSource configures the dialing for TLS. The server X509-SVID is
@@ -26,7 +55,11 @@ func TLSClient(authorizer tlsconfig.Authorizer) DialMode {
 // X.509 source. The source must remain valid for the lifetime of the
 // connection. The authorizer is used to authorize the server X509-SVID.
 func TLSClientWithSource(source *workloadapi.X509Source, authorizer tlsconfig.Authorizer) DialMode {
-	panic("not implemented")
+	return &dialMode{
+		tlsType:    typeTLSClient,
+		authorizer: authorizer,
+		source:     source,
+	}
 }
 
 // TLSClientWithSourceOptions configures the dialing for TLS. The server
@@ -34,7 +67,11 @@ func TLSClientWithSource(source *workloadapi.X509Source, authorizer tlsconfig.Au
 // API X.509 source created with the provided source options. The authorizer is
 // used to authorize the server X509-SVID.
 func TLSClientWithSourceOptions(options []workloadapi.X509SourceOption, authorizer tlsconfig.Authorizer) DialMode {
-	panic("not implemented")
+	return &dialMode{
+		tlsType:    typeTLSClient,
+		authorizer: authorizer,
+		options:    options,
+	}
 }
 
 // TLSClientWithConfig configures the dialing for TLS. The server X509-SVID is
@@ -42,7 +79,11 @@ func TLSClientWithSourceOptions(options []workloadapi.X509SourceOption, authoriz
 // source. The source must remain valid for the lifetime of the connection. The
 // authorizer is used to authorize the server X509-SVID.
 func TLSClientWithConfig(bundle x509bundle.Source, authorizer tlsconfig.Authorizer) DialMode {
-	panic("not implemented")
+	return &dialMode{
+		tlsType:    typeTLSClient,
+		authorizer: authorizer,
+		bundle:     bundle,
+	}
 }
 
 // MTLSClient configures the dialing for mutually authenticated TLS (mTLS). The
@@ -50,7 +91,10 @@ func TLSClientWithConfig(bundle x509bundle.Source, authorizer tlsconfig.Authoriz
 // X509-SVID are obtained via the Workload API. The authorizer is used to
 // authorize the server X509-SVID.
 func MTLSClient(authorizer tlsconfig.Authorizer) DialMode {
-	panic("not implemented")
+	return &dialMode{
+		tlsType:    typeMTLSClient,
+		authorizer: authorizer,
+	}
 }
 
 // MTLSClientWithSource configures the dialing for mutally authenticated TLS
@@ -59,7 +103,11 @@ func MTLSClient(authorizer tlsconfig.Authorizer) DialMode {
 // The source must remain valid for the lifetime of the connection. The
 // authorizer is used to authorize the server X509-SVID.
 func MTLSClientWithSource(source *workloadapi.X509Source, authorizer tlsconfig.Authorizer) DialMode {
-	panic("not implemented")
+	return &dialMode{
+		tlsType:    typeMTLSClient,
+		authorizer: authorizer,
+		source:     source,
+	}
 }
 
 // MTLSClientWithSourceOptions configures the dialing for mutually
@@ -68,7 +116,11 @@ func MTLSClientWithSource(source *workloadapi.X509Source, authorizer tlsconfig.A
 // source created with the provided source options. The authorizer is used to
 // authorize the server X509-SVID.
 func MTLSClientWithSourceOptions(options []workloadapi.X509SourceOption, authorizer tlsconfig.Authorizer) DialMode {
-	panic("not implemented")
+	return &dialMode{
+		tlsType:    typeMTLSClient,
+		authorizer: authorizer,
+		options:    options,
+	}
 }
 
 // MTLSClientWithConfig configures the dialing for mutually authenticated TLS
@@ -77,14 +129,22 @@ func MTLSClientWithSourceOptions(options []workloadapi.X509SourceOption, authori
 // sources. The sources must remain valid for the lifetime of the connection.
 // The authorizer is used to authorize the server X509-SVID.
 func MTLSClientWithConfig(svid x509svid.Source, bundle x509bundle.Source, authorizer tlsconfig.Authorizer) DialMode {
-	panic("not implemented")
+	return &dialMode{
+		tlsType:    typeMTLSClient,
+		authorizer: authorizer,
+		svid:       svid,
+		bundle:     bundle,
+	}
 }
 
 // MTLSWebClient configures the dialing for mutually authenticated TLS (mTLS).
 // The client X509-SVID is obtained via the Workload API. The roots (or the
 // system roots if nil) are used to authenticate the server certificate.
 func MTLSWebClient(roots *x509.CertPool) DialMode {
-	panic("not implemented")
+	return &dialMode{
+		tlsType: typeMTLSWebClient,
+		roots:   roots,
+	}
 }
 
 // MTLSWebClientWithSource configures the dialing for mutually authenticated
@@ -93,7 +153,11 @@ func MTLSWebClient(roots *x509.CertPool) DialMode {
 // connection. The roots (or the system roots if nil) are used to authenticate
 // the server certificate.
 func MTLSWebClientWithSource(source *workloadapi.X509Source, roots *x509.CertPool) DialMode {
-	panic("not implemented")
+	return &dialMode{
+		tlsType: typeMTLSWebClient,
+		source:  source,
+		roots:   roots,
+	}
 }
 
 // MTLSWebClientWithSourceOptions configures the dialing for mutually
@@ -102,7 +166,11 @@ func MTLSWebClientWithSource(source *workloadapi.X509Source, roots *x509.CertPoo
 // roots (or the system roots if nil) are used to authenticate the server
 // certificate.
 func MTLSWebClientWithSourceOptions(options []workloadapi.X509SourceOption, roots *x509.CertPool) DialMode {
-	panic("not implemented")
+	return &dialMode{
+		tlsType: typeMTLSWebClient,
+		options: options,
+		roots:   roots,
+	}
 }
 
 // MTLSWebClientWithConfig configures the dialing for mutually authenticated
@@ -111,7 +179,11 @@ func MTLSWebClientWithSourceOptions(options []workloadapi.X509SourceOption, root
 // roots (or the system roots if nil) are used to authenticate the server
 // certificate.
 func MTLSWebClientWithConfig(svid x509svid.Source, roots *x509.CertPool) DialMode {
-	panic("not implemented")
+	return &dialMode{
+		tlsType: typeMTLSWebClient,
+		svid:    svid,
+		roots:   roots,
+	}
 }
 
 // ListenMode is a SPIFFE TLS listening mode.

--- a/v2/spiffetls/option.go
+++ b/v2/spiffetls/option.go
@@ -11,34 +11,35 @@ var spiffetlsErr = errs.Class("spiffetls")
 
 // DialOption is an option for dialing. Option's are also DialOption's.
 type DialOption interface {
-	apply(*dialOption)
+	apply(*dialConfig)
 }
 
-type dialOption struct {
+type dialOption func(*dialConfig)
+
+func (fn dialOption) apply(c *dialConfig) {
+	fn(c)
+}
+
+type dialConfig struct {
 	baseTLSConf *tls.Config
 	dialer      *net.Dialer
-}
-
-func (o *dialOption) apply(other *dialOption) {
-	if other.baseTLSConf == nil {
-		other.baseTLSConf = o.baseTLSConf
-	}
-	if other.dialer == nil {
-		other.dialer = o.dialer
-	}
 }
 
 // WithDialTLSConfigBase provides a base TLS configuration to use. Fields
 // related to certificates and verification will be overwritten by this package
 // as necessary to facilitate SPIFFE authentication.
 func WithDialTLSConfigBase(base *tls.Config) DialOption {
-	return &dialOption{baseTLSConf: base}
+	return dialOption(func(c *dialConfig) {
+		c.baseTLSConf = base
+	})
 }
 
 // WithDialer provides a net dialer to use. If unset, the standard net dialer
 // will be used.
 func WithDialer(dialer *net.Dialer) DialOption {
-	return &dialOption{dialer: dialer}
+	return dialOption(func(c *dialConfig) {
+		c.dialer = dialer
+	})
 }
 
 // ListenOption is an option for listening. Option's are also ListenOption's.

--- a/v2/spiffetls/option.go
+++ b/v2/spiffetls/option.go
@@ -3,22 +3,42 @@ package spiffetls
 import (
 	"crypto/tls"
 	"net"
+
+	"github.com/zeebo/errs"
 )
 
+var spiffetlsErr = errs.Class("spiffetls")
+
 // DialOption is an option for dialing. Option's are also DialOption's.
-type DialOption interface{}
+type DialOption interface {
+	apply(*dialOption)
+}
+
+type dialOption struct {
+	baseTLSConf *tls.Config
+	dialer      *net.Dialer
+}
+
+func (o *dialOption) apply(other *dialOption) {
+	if other.baseTLSConf == nil {
+		other.baseTLSConf = o.baseTLSConf
+	}
+	if other.dialer == nil {
+		other.dialer = o.dialer
+	}
+}
 
 // WithDialTLSConfigBase provides a base TLS configuration to use. Fields
 // related to certificates and verification will be overwritten by this package
 // as necessary to facilitate SPIFFE authentication.
 func WithDialTLSConfigBase(base *tls.Config) DialOption {
-	panic("not implemented")
+	return &dialOption{baseTLSConf: base}
 }
 
 // WithDialer provides a net dialer to use. If unset, the standard net dialer
 // will be used.
 func WithDialer(dialer *net.Dialer) DialOption {
-	panic("not implemented")
+	return &dialOption{dialer: dialer}
 }
 
 // ListenOption is an option for listening. Option's are also ListenOption's.


### PR DESCRIPTION
This PR implements the dialing functions for `spiffetls` package.
I am still working on unit tests, but pushing this initial PR to validate the approach, get some early feedback and coordinate with the listening ticket implementation.

Fixes: #72 