### PR TITLE
add RequireFromString/RequireFromURI

### DIFF
--- a/v2/spiffeid/id.go
+++ b/v2/spiffeid/id.go
@@ -106,6 +106,28 @@ func FromURI(uri *url.URL) (ID, error) {
 	}, nil
 }
 
+// RequireFromString is similar to FromString except that instead of returning
+// an error on malformed input, it panics. It should only be used when given
+// string is statically verifiable.
+func RequireFromString(s string) ID {
+	id, err := FromString(s)
+	if err != nil {
+		panic(err)
+	}
+	return id
+}
+
+// RequireFromURI is similar to FromURI except that instead of returning
+// an error on malformed input, it panics. It should only be used when given
+// string is statically verifiable.
+func RequireFromURI(uri *url.URL) ID {
+	id, err := FromURI(uri)
+	if err != nil {
+		panic(err)
+	}
+	return id
+}
+
 // TrustDomain returns the trust domain of the SPIFFE ID.
 func (id ID) TrustDomain() TrustDomain {
 	return id.td

--- a/v2/spiffeid/id_test.go
+++ b/v2/spiffeid/id_test.go
@@ -242,6 +242,15 @@ func TestFromString(t *testing.T) {
 	}
 }
 
+func TestRequireFromString(t *testing.T) {
+	require.NotPanics(t, func() {
+		spiffeid.RequireFromString("spiffe://domain.test")
+	})
+	require.Panics(t, func() {
+		spiffeid.RequireFromString("BAD")
+	})
+}
+
 func TestFromURI(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -339,6 +348,15 @@ func TestFromURI(t *testing.T) {
 			assert.Equal(t, test.expectedID, id)
 		})
 	}
+}
+
+func TestRequireFromURI(t *testing.T) {
+	require.NotPanics(t, func() {
+		spiffeid.RequireFromURI(&url.URL{Scheme: "spiffe", Host: "example.org"})
+	})
+	require.Panics(t, func() {
+		spiffeid.RequireFromURI(&url.URL{Host: "BAD"})
+	})
 }
 
 func TestIDTrustDomain(t *testing.T) {


### PR DESCRIPTION
This adds feature parity with the trust domain methods.

Signed-off-by: Andrew Harding <andrew.harding@hpe.com>