### PR TITLE
Add V2 README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,15 @@
-# go-spiffe library [![GoDoc](https://godoc.org/github.com/spiffe/go-spiffe?status.svg)](https://godoc.org/github.com/spiffe/go-spiffe)
+# go-spiffe (v1) library [![GoDoc](https://godoc.org/github.com/spiffe/go-spiffe?status.svg)](https://godoc.org/github.com/spiffe/go-spiffe)
+
+# Deprecation Warning
+
+__NOTE:__ This version of the library will be deprecated soon.
+
+The new [v2](./v2) module is currently in alpha release and published under
+`github.com/spiffe/go-spiffe/v2`, following go module guidelines.
+
+New code should consider using the `v2` module.
+
+See the [v2 README](./v2) for more details.
 
 ## Overview
 
@@ -15,8 +26,7 @@ go get -u -v github.com/spiffe/go-spiffe
 
 ## Importing it in your Go code
 
-See examples in [the tests](./spiffetest), [the examples section](./examples)
-or visit the [GoDoc](https://godoc.org/github.com/spiffe/go-spiffe) for more information
+See the [examples](./examples) or visit the [documentation](https://pkg.go.dev/github.com/spiffe/go-spiffe) for more information.
 
 ## Installing the command line interface
 The command line interface can be used to retrieve and view URIs stored

--- a/v2/README.md
+++ b/v2/README.md
@@ -1,0 +1,46 @@
+#  go-spiffe (v2)
+
+This library is a convenient Go library for working with [SPIFFE](https://spiffe.io/).
+
+It leverages the [SPIFFE Workload API](https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE_Workload_API.md), providing high level functionality that includes:
+* Establishing mutually authenticated TLS (__mTLS__) between workloads powered by SPIFFE.
+* Obtaining and validating [X509-SVIDs](https://github.com/spiffe/spiffe/blob/master/standards/X509-SVID.md) and [JWT-SVIDs](https://github.com/spiffe/spiffe/blob/master/standards/JWT-SVID.md).
+* Federating trust between trust domains using [SPIFFE bundles](https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE_Trust_Domain_and_Bundle.md#3-spiffe-bundles).
+* Bundle management.
+
+## Documentation
+
+See the [Go Package](https://pkg.go.dev/github.com/spiffe/go-spiffe/v2) documentation.
+
+## Quick Start
+
+Prerequisites:
+1. Running [SPIRE](https://spiffe.io/spire/) or another SPIFFE Workload API
+   implementation.
+2. `SPIFFE_ENDPOINT_SOCKET` environment variable set to address of the Workload
+   API (e.g. `unix:///tmp/agent.sock`). Alternatively the socket address can be
+   provided programatically.
+
+To create an mTLS server:
+
+```go
+listener, err := spiffetls.Listen(ctx, "tcp", "127.0.0.1:8443", tlsconfig.AuthorizeAny())
+```
+
+To dial an mTLS server:
+
+```go
+conn, err := spiffetls.Dial(ctx, "tcp", "127.0.0.1:8443", tlsconfig.AuthorizeAny())
+```
+
+The client and server obtain
+[X509-SVIDs](https://github.com/spiffe/spiffe/blob/master/standards/X509-SVID.md)
+and X.509 bundles from the [SPIFFE Workload
+API](https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE_Workload_API.md).
+The X509-SVIDs are presented by each peer and authenticated against the X.509
+bundles. Both sides continue to be updated with X509-SVIDs and X.509 bundles
+streamed from the Workload API (e.g. secret rotation).
+
+## Examples
+
+The [examples](./examples) directory contains rich examples for a variety of circumstances.

--- a/v2/examples/README.md
+++ b/v2/examples/README.md
@@ -1,0 +1,3 @@
+# go-spiffe (v2) Examples
+
+TODO


### PR DESCRIPTION
This provides a basic README for the v2 library and a placeholder README for the examples (which will be updated soon).

It also adds a deprecation warning to the v1 readme.