### PR TITLE
Small fixes and other test scaffolding cleanup

### DIFF
--- a/v2/bundle/spiffebundle/bundle_test.go
+++ b/v2/bundle/spiffebundle/bundle_test.go
@@ -152,18 +152,18 @@ func TestTrustDomain(t *testing.T) {
 func TestJWTAuthoritiesCRUD(t *testing.T) {
 	// Test AddJWTAuthority (missing authority)
 	b := spiffebundle.New(td)
-	err := b.AddJWTAuthorities("", "test-1")
+	err := b.AddJWTAuthority("", "test-1")
 	require.EqualError(t, err, "spiffebundle: keyID cannot be empty")
 
 	// Test AddJWTAuthority (new authority)
-	err = b.AddJWTAuthorities("key-1", "test-1")
+	err = b.AddJWTAuthority("key-1", "test-1")
 	require.NoError(t, err)
 
 	// Test JWTAuthorities
 	jwtAuthorities := b.JWTAuthorities()
 	require.Equal(t, map[string]crypto.PublicKey{"key-1": "test-1"}, jwtAuthorities)
 
-	err = b.AddJWTAuthorities("key-2", "test-2")
+	err = b.AddJWTAuthority("key-2", "test-2")
 	require.NoError(t, err)
 
 	jwtAuthorities = b.JWTAuthorities()
@@ -194,7 +194,7 @@ func TestJWTAuthoritiesCRUD(t *testing.T) {
 	require.Equal(t, true, b.HasJWTAuthority("key-1"))
 
 	// Test AddJWTAuthority (update authority)
-	err = b.AddJWTAuthorities("key-1", "test-1-updated")
+	err = b.AddJWTAuthority("key-1", "test-1-updated")
 	require.NoError(t, err)
 	jwtAuthorities = b.JWTAuthorities()
 	require.Equal(t, map[string]crypto.PublicKey{
@@ -290,7 +290,7 @@ func TestX509Bundle(t *testing.T) {
 
 func TestJWTBundle(t *testing.T) {
 	sb := spiffebundle.New(td)
-	err := sb.AddJWTAuthorities("key-1", "test-1")
+	err := sb.AddJWTAuthority("key-1", "test-1")
 	require.NoError(t, err)
 	jb := sb.JWTBundle()
 	require.Equal(t, true, jb.HasJWTAuthority("key-1"))
@@ -318,7 +318,7 @@ func TestGetX509BundleForTrustDomain(t *testing.T) {
 	td2 := spiffeid.RequireTrustDomainFromString("example-2.org")
 	xb2, err = sb.GetX509BundleForTrustDomain(td2)
 	require.Nil(t, xb2)
-	require.EqualError(t, err, `spiffebundle: no SPIFFE bundle for trust domain "example-2.org"`)
+	require.EqualError(t, err, `spiffebundle: no X.509 bundle for trust domain "example-2.org"`)
 }
 
 func TestGetJWTBundleForTrustDomain(t *testing.T) {
@@ -331,7 +331,7 @@ func TestGetJWTBundleForTrustDomain(t *testing.T) {
 	td2 := spiffeid.RequireTrustDomainFromString("example-2.org")
 	jb2, err = sb.GetJWTBundleForTrustDomain(td2)
 	require.Nil(t, jb2)
-	require.EqualError(t, err, `spiffebundle: no SPIFFE bundle for trust domain "example-2.org"`)
+	require.EqualError(t, err, `spiffebundle: no JWT bundle for trust domain "example-2.org"`)
 }
 
 func checkBundleProperties(t *testing.T, err error, tc testCase, b *spiffebundle.Bundle) {

--- a/v2/bundle/spiffebundle/set.go
+++ b/v2/bundle/spiffebundle/set.go
@@ -114,7 +114,7 @@ func (s *Set) GetX509BundleForTrustDomain(trustDomain spiffeid.TrustDomain) (*x5
 
 	bundle, ok := s.bundles[trustDomain]
 	if !ok {
-		return nil, spiffebundleErr.New("no SPIFFE bundle for trust domain %q", trustDomain)
+		return nil, spiffebundleErr.New("no X.509 bundle for trust domain %q", trustDomain)
 	}
 
 	return bundle.X509Bundle(), nil
@@ -128,7 +128,7 @@ func (s *Set) GetJWTBundleForTrustDomain(trustDomain spiffeid.TrustDomain) (*jwt
 
 	bundle, ok := s.bundles[trustDomain]
 	if !ok {
-		return nil, spiffebundleErr.New("no SPIFFE bundle for trust domain %q", trustDomain)
+		return nil, spiffebundleErr.New("no JWT bundle for trust domain %q", trustDomain)
 	}
 
 	return bundle.JWTBundle(), nil

--- a/v2/bundle/spiffebundle/set_test.go
+++ b/v2/bundle/spiffebundle/set_test.go
@@ -63,7 +63,7 @@ func TestSetGetX509BundleForTrustDomain(t *testing.T) {
 	b := spiffebundle.FromX509Bundle(xb1)
 	s := spiffebundle.NewSet(b)
 	_, err := s.GetX509BundleForTrustDomain(td2)
-	require.EqualError(t, err, `spiffebundle: no SPIFFE bundle for trust domain "example-2.org"`)
+	require.EqualError(t, err, `spiffebundle: no X.509 bundle for trust domain "example-2.org"`)
 
 	xb2, err := s.GetX509BundleForTrustDomain(td)
 	require.NoError(t, err)
@@ -79,7 +79,7 @@ func TestSetGetJWTBundleForTrustDomain(t *testing.T) {
 	b := spiffebundle.FromJWTBundle(jb1)
 	s := spiffebundle.NewSet(b)
 	_, err := s.GetJWTBundleForTrustDomain(td2)
-	require.EqualError(t, err, `spiffebundle: no SPIFFE bundle for trust domain "example-2.org"`)
+	require.EqualError(t, err, `spiffebundle: no JWT bundle for trust domain "example-2.org"`)
 
 	jb2, err := s.GetJWTBundleForTrustDomain(td)
 	require.NoError(t, err)

--- a/v2/federation/watch_test.go
+++ b/v2/federation/watch_test.go
@@ -12,13 +12,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestWatchBundle_OnUpate(t *testing.T) {
+func TestWatchBundle_OnUpdate(t *testing.T) {
 	var watcher *fakewatcher
-	ca1 := test.NewCA(t)
-	bundle1 := spiffebundle.FromX509Bundle(ca1.Bundle(td))
+	ca1 := test.NewCA(t, td)
+	bundle1 := ca1.Bundle()
 	bundle1.SetRefreshHint(time.Second)
-	ca2 := test.NewCA(t)
-	bundle2 := spiffebundle.FromX509Bundle(ca2.Bundle(td))
+	ca2 := test.NewCA(t, td)
+	bundle2 := ca2.Bundle()
 	bundle2.SetRefreshHint(2 * time.Second)
 	bundles := []*spiffebundle.Bundle{bundle1, bundle2}
 
@@ -101,7 +101,7 @@ func (w *fakewatcher) NextRefresh(refreshHint time.Duration) time.Duration {
 
 func (w *fakewatcher) OnUpdate(bundle *spiffebundle.Bundle) {
 	w.latestBundle = bundle
-	assert.True(w.t, bundle.Equal(w.expectedBundles[w.onUpdateCalls]))
+	assert.Equal(w.t, w.expectedBundles[w.onUpdateCalls], bundle)
 	w.onUpdateCalls++
 	w.cancel()
 }

--- a/v2/internal/x509util/util.go
+++ b/v2/internal/x509util/util.go
@@ -35,3 +35,19 @@ func CertsEqual(a, b []*x509.Certificate) bool {
 
 	return true
 }
+
+func RawCertsFromCerts(certs []*x509.Certificate) [][]byte {
+	rawCerts := make([][]byte, 0, len(certs))
+	for _, cert := range certs {
+		rawCerts = append(rawCerts, cert.Raw)
+	}
+	return rawCerts
+}
+
+func ConcatRawCertsFromCerts(certs []*x509.Certificate) []byte {
+	var rawCerts []byte
+	for _, cert := range certs {
+		rawCerts = append(rawCerts, cert.Raw...)
+	}
+	return rawCerts
+}

--- a/v2/svid/x509svid/svid.go
+++ b/v2/svid/x509svid/svid.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 
 	"github.com/spiffe/go-spiffe/v2/internal/pemutil"
+	"github.com/spiffe/go-spiffe/v2/internal/x509util"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/zeebo/errs"
 )
@@ -105,12 +106,9 @@ func (s *SVID) MarshalRaw() ([]byte, []byte, error) {
 	if len(s.Certificates) == 0 {
 		return nil, nil, x509svidErr.New("no certificates to marshal")
 	}
-	certBytes := []byte{}
-	for _, cert := range s.Certificates {
-		certBytes = append(certBytes, cert.Raw...)
-	}
 
-	return certBytes, key, nil
+	certs := x509util.ConcatRawCertsFromCerts(s.Certificates)
+	return certs, key, nil
 }
 
 // GetX509SVID returns the X509-SVID. It implements the Source interface.

--- a/v2/workloadapi/client.go
+++ b/v2/workloadapi/client.go
@@ -285,6 +285,7 @@ func (c *Client) watchX509Context(ctx context.Context, watcher X509ContextWatche
 		c.backoff.Reset()
 		x509Context, err := parseX509SVIDResponse(resp)
 		if err != nil {
+			c.config.log.Errorf("Failed to parse X509-SVID response: %v", err)
 			watcher.OnX509ContextWatchError(err)
 			continue
 		}
@@ -311,6 +312,7 @@ func (c *Client) watchJWTBundles(ctx context.Context, watcher JWTBundleWatcher) 
 		c.backoff.Reset()
 		jwtbundleSet, err := parseJWTSVIDBundles(resp)
 		if err != nil {
+			c.config.log.Errorf("Failed to parse JWT bundle response: %v", err)
 			watcher.OnJWTBundlesWatchError(err)
 			continue
 		}


### PR DESCRIPTION
- Rename AddJWTAuthorities to AddJWTAuthority on SPIFFE bundle.
- Fix SPIFFE bundle JWT map being improperly initialized in some From*
methods.
- Cleaned up some error messaging in SPIFFE bundle
Get*BundleForTrustDomain methods
- Test CA now takes a trust domain to clean up usage.
- Test CA Bundle() method now returns a SPIFFE bundle
- Test CA gains the X509Bundle() and JWTBundle() methods
- Test CA SVID creation uses strong types and returns actual SVID types
- Other test CA cleanup and method renames for consistency
- Fake WorkloadAPI has more convenient methods for setting JWT bundle
responses.
- Fake WorkloadAPI X509 response setting uses more convenient types.