### PR TITLE
Disable automatic skips on lint, to catch errors on examples

### DIFF
--- a/v2/.golangci.yml
+++ b/v2/.golangci.yml
@@ -2,6 +2,9 @@ run:
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   deadline: 10m
 
+  # include examples
+  skip-dirs-use-default: false
+
   skip-dirs:
     - testdata$
     - test/mock

--- a/v2/examples/spiffe-http/server/main.go
+++ b/v2/examples/spiffe-http/server/main.go
@@ -21,7 +21,7 @@ func main() {
 	// Set up a `/` resource handler
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		log.Println("call received")
-		io.WriteString(w, "Success!!!")
+		_, _ = io.WriteString(w, "Success!!!")
 	})
 
 	// Create a `workloadapi.X509Source`, it will connect to Workload API using provided socket.


### PR DESCRIPTION
Signed-off-by: Marcos Yacob <marcos@scytale.io>