### PR TITLE
Reject Workload API responses missing the bundle

### DIFF
--- a/v2/workloadapi/client.go
+++ b/v2/workloadapi/client.go
@@ -74,7 +74,7 @@ func (c *Client) FetchX509SVID(ctx context.Context) (*x509svid.SVID, error) {
 		return nil, err
 	}
 
-	svids, err := parseX509SVIDs(resp, 1)
+	svids, err := parseX509SVIDs(resp, true)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +97,7 @@ func (c *Client) FetchX509SVIDs(ctx context.Context) ([]*x509svid.SVID, error) {
 		return nil, err
 	}
 
-	return parseX509SVIDs(resp, -1)
+	return parseX509SVIDs(resp, false)
 }
 
 // FetchX509Bundles fetches the X.509 bundles.
@@ -348,7 +348,7 @@ func defaultClientConfig() clientConfig {
 }
 
 func parseX509Context(resp *workload.X509SVIDResponse) (*X509Context, error) {
-	svids, err := parseX509SVIDs(resp, -1)
+	svids, err := parseX509SVIDs(resp, false)
 	if err != nil {
 		return nil, err
 	}
@@ -364,14 +364,13 @@ func parseX509Context(resp *workload.X509SVIDResponse) (*X509Context, error) {
 	}, nil
 }
 
-// parseX509SVIDs parses between 1 and n SVIDs from the response. It fails
-// if it cannot parse at least one, since the SVID is required in the response
-// and the spec indicates clients SHOULD reject such messages. If n is less
-// than one, then all SVIDs are returned.
-func parseX509SVIDs(resp *workload.X509SVIDResponse, n int) ([]*x509svid.SVID, error) {
-	switch {
-	case n < 1, n > len(resp.Svids):
-		n = len(resp.Svids)
+// parseX509SVIDs parses one or all of the SVIDs in the response. If firstOnly
+// is true, then only the first SVID in the response is parsed and returned.
+// Otherwise all SVIDs are parsed and returned.
+func parseX509SVIDs(resp *workload.X509SVIDResponse, firstOnly bool) ([]*x509svid.SVID, error) {
+	n := len(resp.Svids)
+	if firstOnly {
+		n = 1
 	}
 
 	svids := make([]*x509svid.SVID, 0, n)

--- a/v2/workloadapi/client_test.go
+++ b/v2/workloadapi/client_test.go
@@ -91,13 +91,13 @@ func TestFetchX509Bundles(t *testing.T) {
 	require.Len(t, bundles.Bundles(), 2)
 	//TODO: inspect bundles
 
-	// Now set the next response without any bundles and Assert that the call
-	// since the bundle cannot be empty.
+	// Now set the next response without any bundles and assert that the call
+	// fails since the bundle cannot be empty.
 	wl.SetX509SVIDResponse(&fakeworkloadapi.X509SVIDResponse{
 		SVIDs: svids,
 	})
 	bundles, err = c.FetchX509Bundles(context.Background())
-	require.EqualError(t, err, `empty X.509 bundle for trust domain "example.org"`, td)
+	require.EqualError(t, err, `empty X.509 bundle for trust domain "example.org"`)
 	require.Nil(t, bundles)
 }
 
@@ -127,13 +127,13 @@ func TestFetchX509Context(t *testing.T) {
 	assert.Len(t, x509Ctx.Bundles.Bundles(), 2)
 	//TODO: inspect bundles
 
-	// Now set the next response without any bundles and Assert that the call
-	// since the bundle cannot be empty.
+	// Now set the next response without any bundles and assert that the call
+	// fails since the bundle cannot be empty.
 	wl.SetX509SVIDResponse(&fakeworkloadapi.X509SVIDResponse{
 		SVIDs: svids,
 	})
 	x509Ctx, err = c.FetchX509Context(context.Background())
-	require.EqualError(t, err, `empty X.509 bundle for trust domain "example.org"`, td)
+	require.EqualError(t, err, `empty X.509 bundle for trust domain "example.org"`)
 	require.Nil(t, x509Ctx)
 }
 

--- a/v2/workloadapi/client_test.go
+++ b/v2/workloadapi/client_test.go
@@ -37,7 +37,7 @@ func TestFetchX509SVID(t *testing.T) {
 	wl.SetX509SVIDResponse(resp)
 	svid, err := c.FetchX509SVID(context.Background())
 
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "spiffe://example.org/foo", svid.ID.String())
 	assert.Len(t, svid.Certificates, 1)
 	assert.NotEmpty(t, svid.PrivateKey)
@@ -58,7 +58,7 @@ func TestFetchX509SVIDs(t *testing.T) {
 	wl.SetX509SVIDResponse(resp)
 
 	svids, err := c.FetchX509SVIDs(context.Background())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Len(t, svids, 2)
 	assert.Equal(t, "spiffe://example.org/foo", svids[0].ID.String())
 	assert.NotEmpty(t, svids[0].PrivateKey)
@@ -78,17 +78,27 @@ func TestFetchX509Bundles(t *testing.T) {
 	defer c.Close()
 	defer c.Close()
 
-	resp := &fakeworkloadapi.X509SVIDResponse{
+	svids := makeX509SVIDs(ca, "spiffe://example.org/foo", "spiffe://example.org/bar")
+
+	wl.SetX509SVIDResponse(&fakeworkloadapi.X509SVIDResponse{
 		Bundle:           ca.X509Bundle(),
-		SVIDs:            makeX509SVIDs(ca, "spiffe://example.org/foo", "spiffe://example.org/bar"),
+		SVIDs:            svids,
 		FederatedBundles: []*x509bundle.Bundle{federatedCA.X509Bundle()},
-	}
-	wl.SetX509SVIDResponse(resp)
+	})
 
 	bundles, err := c.FetchX509Bundles(context.Background())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Len(t, bundles.Bundles(), 2)
 	//TODO: inspect bundles
+
+	// Now set the next response without any bundles and Assert that the call
+	// since the bundle cannot be empty.
+	wl.SetX509SVIDResponse(&fakeworkloadapi.X509SVIDResponse{
+		SVIDs: svids,
+	})
+	bundles, err = c.FetchX509Bundles(context.Background())
+	require.EqualError(t, err, `empty X.509 bundle for trust domain "example.org"`, td)
+	require.Nil(t, bundles)
 }
 
 func TestFetchX509Context(t *testing.T) {
@@ -101,19 +111,30 @@ func TestFetchX509Context(t *testing.T) {
 	defer c.Close()
 	defer c.Close()
 
+	svids := makeX509SVIDs(ca, "spiffe://example.org/foo", "spiffe://example.org/bar")
+
 	resp := &fakeworkloadapi.X509SVIDResponse{
 		Bundle:           ca.X509Bundle(),
-		SVIDs:            makeX509SVIDs(ca, "spiffe://example.org/foo", "spiffe://example.org/bar"),
+		SVIDs:            svids,
 		FederatedBundles: []*x509bundle.Bundle{federatedCA.X509Bundle()},
 	}
 	wl.SetX509SVIDResponse(resp)
 
 	x509Ctx, err := c.FetchX509Context(context.Background())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Len(t, x509Ctx.SVIDs, 2)
 	//TODO: inspect svids
 	assert.Len(t, x509Ctx.Bundles.Bundles(), 2)
 	//TODO: inspect bundles
+
+	// Now set the next response without any bundles and Assert that the call
+	// since the bundle cannot be empty.
+	wl.SetX509SVIDResponse(&fakeworkloadapi.X509SVIDResponse{
+		SVIDs: svids,
+	})
+	x509Ctx, err = c.FetchX509Context(context.Background())
+	require.EqualError(t, err, `empty X.509 bundle for trust domain "example.org"`, td)
+	require.Nil(t, x509Ctx)
 }
 
 func TestWatchX509Context(t *testing.T) {
@@ -196,7 +217,7 @@ func TestFetchJWTSVID(t *testing.T) {
 
 	jwtSvid, err := c.FetchJWTSVID(context.Background(), params)
 
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "spiffe://example.org/mytoken", jwtSvid.ID.String())
 	assert.Equal(t, []string{"spiffe://example.org/audience", "spiffe://example.org/extra_audience"}, jwtSvid.Audience)
 	assert.NotNil(t, jwtSvid.Claims)
@@ -216,7 +237,7 @@ func TestFetchJWTBundles(t *testing.T) {
 
 	bundleSet, err := c.FetchJWTBundles(context.Background())
 
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 1, bundleSet.Len())
 	assert.True(t, bundleSet.Has(td))
 	bundle, ok := bundleSet.Get(td)
@@ -293,13 +314,13 @@ func TestValidateJWTSVID(t *testing.T) {
 
 	t.Run("first audience is valid", func(t *testing.T) {
 		jwtSvid, err := c.ValidateJWTSVID(context.Background(), token, audience[0])
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.NotNil(t, jwtSvid)
 	})
 
 	t.Run("second audience is valid", func(t *testing.T) {
 		jwtSvid, err := c.ValidateJWTSVID(context.Background(), token, audience[1])
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.NotNil(t, jwtSvid)
 	})
 


### PR DESCRIPTION
The Workload API specification says that clients SHOULD reject messages that with unset fields in the SVID message. The bundle is part of that message. The current code allows an empty bundle field. In particular, this means that the FetchX509Context and FetchX509Bundles calls can return empty bundle contents.

Considering the "SHOULD" guidance, this change updates the client to reject empty bundles. This only impacts the X.509 related calls that return bundle information, but not calls that only return the SVID (e.g. FetchX509SVID).

I'd be open to being more restrictive and downright rejecting messages from the Workload API that have missing fields in the SVID message of any kind, but this seemed like a good minimal step.

Also took the opportunity to DRY up some of the response handling code.