### PR TITLE
Solve tls config flaky test

### DIFF
--- a/v2/spiffetls/tlsconfig/config_test.go
+++ b/v2/spiffetls/tlsconfig/config_test.go
@@ -688,14 +688,19 @@ func testConnection(t testing.TB, serverConfig *tls.Config, clientConfig *tls.Co
 		}
 		require.NoError(t, err)
 	}()
+
+	complete := make(chan struct{})
+	defer close(complete)
 	go func() {
 		errCh <- func() error {
 			conn, err := ln.Accept()
 			if err != nil {
 				return err
 			}
-			defer conn.Close()
-
+			defer func() {
+				<-complete
+				conn.Close()
+			}()
 			buf := make([]byte, 1)
 			if _, err = conn.Read(buf); err != nil {
 				return err

--- a/v2/spiffetls/tlsconfig/config_test.go
+++ b/v2/spiffetls/tlsconfig/config_test.go
@@ -689,8 +689,8 @@ func testConnection(t testing.TB, serverConfig *tls.Config, clientConfig *tls.Co
 		require.NoError(t, err)
 	}()
 
-	complete := make(chan struct{})
-	defer close(complete)
+	done := make(chan struct{})
+	defer close(done)
 	go func() {
 		errCh <- func() error {
 			conn, err := ln.Accept()
@@ -698,7 +698,7 @@ func testConnection(t testing.TB, serverConfig *tls.Config, clientConfig *tls.Co
 				return err
 			}
 			defer func() {
-				<-complete
+				<-done
 				conn.Close()
 			}()
 			buf := make([]byte, 1)


### PR DESCRIPTION
Prevent connection to be closed before test finished on tls config handshake tests

Signed-off-by: Marcos Yacob <marcos@scytale.io>