### PR TITLE
v2: rename Empty() to IsZero()

### DIFF
--- a/v2/spiffeid/id.go
+++ b/v2/spiffeid/id.go
@@ -146,7 +146,7 @@ func (id ID) Path() string {
 // String returns the string representation of the SPIFFE ID, e.g.,
 // "spiffe://example.org/foo/bar".
 func (id ID) String() string {
-	if id.Empty() {
+	if id.IsZero() {
 		return ""
 	}
 
@@ -155,7 +155,7 @@ func (id ID) String() string {
 
 // URL returns a URL for SPIFFE ID.
 func (id ID) URL() *url.URL {
-	if id.Empty() {
+	if id.IsZero() {
 		return &url.URL{}
 	}
 
@@ -166,9 +166,9 @@ func (id ID) URL() *url.URL {
 	}
 }
 
-// Empty returns true if the SPIFFE ID is empty.
-func (id ID) Empty() bool {
-	return id.td.Empty()
+// IsZero returns true if the SPIFFE ID is the zero value.
+func (id ID) IsZero() bool {
+	return id.td.IsZero()
 }
 
 func normalizeTrustDomain(td string) string {

--- a/v2/spiffeid/id_test.go
+++ b/v2/spiffeid/id_test.go
@@ -474,8 +474,8 @@ func TestIDURL(t *testing.T) {
 	assert.Equal(t, &url.URL{}, id.URL())
 }
 
-func TestIDEmpty(t *testing.T) {
-	assert.True(t, spiffeid.ID{}.Empty())
+func TestIDIsZero(t *testing.T) {
+	assert.True(t, spiffeid.ID{}.IsZero())
 }
 
 func parseURI(t *testing.T, id string) *url.URL {

--- a/v2/spiffeid/trustdomain.go
+++ b/v2/spiffeid/trustdomain.go
@@ -88,8 +88,8 @@ func (td TrustDomain) NewID(path string) ID {
 	}
 }
 
-// Empty returns true if the trust domain value is empty.
-func (td TrustDomain) Empty() bool {
+// IsZero returns true if the trust domain is the zero value.
+func (td TrustDomain) IsZero() bool {
 	return td.name == ""
 }
 

--- a/v2/spiffeid/trustdomain_test.go
+++ b/v2/spiffeid/trustdomain_test.go
@@ -205,6 +205,6 @@ func TestTrustDomainNewID(t *testing.T) {
 	assert.Equal(t, id, td.NewID(""))
 }
 
-func TestTrustDomainEmpty(t *testing.T) {
-	assert.True(t, spiffeid.TrustDomain{}.Empty())
+func TestTrustDomainIsZero(t *testing.T) {
+	assert.True(t, spiffeid.TrustDomain{}.IsZero())
 }


### PR DESCRIPTION
IsZero is more idiomatic with other structs in the stdlib (e.g., time.Time, reflect.Value).