### PR TITLE
v2: export method to obtain SPIFFE ID from cert

### DIFF
--- a/v2/svid/x509svid/svid.go
+++ b/v2/svid/x509svid/svid.go
@@ -155,7 +155,7 @@ func validateCertificates(certificates []*x509.Certificate) (*spiffeid.ID, error
 }
 
 func validateLeafCertificate(leaf *x509.Certificate) (*spiffeid.ID, error) {
-	leafID, err := getIDFromCertificate(leaf)
+	leafID, err := IDFromCert(leaf)
 	if err != nil {
 		return nil, errs.New("cannot get leaf certificate SPIFFE ID: %v", err)
 	}

--- a/v2/svid/x509svid/verify.go
+++ b/v2/svid/x509svid/verify.go
@@ -23,7 +23,7 @@ func Verify(certs []*x509.Certificate, bundleSource x509bundle.Source) (spiffeid
 	}
 
 	leaf := certs[0]
-	id, err := getIDFromCertificate(leaf)
+	id, err := IDFromCert(leaf)
 	if err != nil {
 		return spiffeid.ID{}, nil, x509svidErr.New("could not get leaf SPIFFE ID: %w", err)
 	}
@@ -69,10 +69,10 @@ func ParseAndVerify(rawCerts [][]byte, bundleSource x509bundle.Source) (spiffeid
 	return Verify(certs, bundleSource)
 }
 
-// getIDFromCertificate extracts the SPIFFE ID from the  URI SAN of the
-// provided certificate. If the certificate has no URI SAN or
-// the SPIFFE ID is malformed, it will return an error.
-func getIDFromCertificate(cert *x509.Certificate) (spiffeid.ID, error) {
+// IDFromCert extracts the SPIFFE ID from the URI SAN of the provided
+// certificate. It will return an an error if the certificate does not have
+// exactly one URI SAN with a well-formed SPIFFE ID.
+func IDFromCert(cert *x509.Certificate) (spiffeid.ID, error) {
 	switch {
 	case len(cert.URIs) == 0:
 		return spiffeid.ID{}, errs.New("certificate contains no URI SAN")


### PR DESCRIPTION
It was brought to my attention that this functionality (exported from v1, more or less) was useful and 
would be nice to include in v2 (thanks, @edwarnicke!).

I chose to export the helper available in the `x509svid` package (with a slight rename).

I'm open to suggestions on naming and the package.

I also removed an equivalent function in `spiffetls` in lieu of code reuse.