### PR TITLE
Print out the expected peer and domains when encountering mismatches

### DIFF
--- a/spiffe/expect.go
+++ b/spiffe/expect.go
@@ -22,7 +22,7 @@ func ExpectAnyPeer() ExpectPeerFunc {
 func ExpectPeer(expectedID string) ExpectPeerFunc {
 	return func(peerID string, _ [][]*x509.Certificate) error {
 		if peerID != expectedID {
-			return fmt.Errorf("unexpected peer ID %q", peerID)
+			return fmt.Errorf("unexpected peer ID %q: expected %q", peerID, expectedID)
 		}
 		return nil
 	}
@@ -36,7 +36,7 @@ func ExpectPeers(expectedIDs ...string) ExpectPeerFunc {
 	}
 	return func(peerID string, _ [][]*x509.Certificate) error {
 		if _, ok := m[peerID]; !ok {
-			return fmt.Errorf("unexpected peer ID %q", peerID)
+			return fmt.Errorf("unexpected peer ID %q: expected one of %q", peerID, expectedIDs)
 		}
 		return nil
 	}
@@ -47,7 +47,7 @@ func ExpectPeers(expectedIDs ...string) ExpectPeerFunc {
 func ExpectPeerInDomain(expectedDomain string) ExpectPeerFunc {
 	return func(peerID string, _ [][]*x509.Certificate) error {
 		if domain := getPeerTrustDomain(peerID); domain != expectedDomain {
-			return fmt.Errorf("unexpected peer trust domain %q", domain)
+			return fmt.Errorf("unexpected trust domain %q for peer ID %q: expected trust domain %q", domain, peerID, expectedDomain)
 		}
 		return nil
 	}

--- a/spiffe/expect_test.go
+++ b/spiffe/expect_test.go
@@ -18,7 +18,7 @@ func TestExpectPeer(t *testing.T) {
 	expect := ExpectPeer("spiffe://domain.test/workload1")
 	assert.NoError(t, expect("spiffe://domain.test/workload1", nil))
 	assert.EqualError(t, expect("spiffe://domain.test/workload2", nil),
-		`unexpected peer ID "spiffe://domain.test/workload2"`)
+		`unexpected peer ID "spiffe://domain.test/workload2": expected "spiffe://domain.test/workload1"`)
 }
 
 func TestExpectPeers(t *testing.T) {
@@ -26,12 +26,12 @@ func TestExpectPeers(t *testing.T) {
 	assert.NoError(t, expect("spiffe://domain.test/workload1", nil))
 	assert.NoError(t, expect("spiffe://domain.test/workload2", nil))
 	assert.EqualError(t, expect("spiffe://domain.test/workload3", nil),
-		`unexpected peer ID "spiffe://domain.test/workload3"`)
+		`unexpected peer ID "spiffe://domain.test/workload3": expected one of ["spiffe://domain.test/workload1" "spiffe://domain.test/workload2"]`)
 }
 
 func TestExpectPeerInDomain(t *testing.T) {
 	expect := ExpectPeerInDomain("domain1.test")
 	assert.NoError(t, expect("spiffe://domain1.test/workload", nil))
 	assert.EqualError(t, expect("spiffe://domain2.test/workload", nil),
-		`unexpected peer trust domain "domain2.test"`)
+		`unexpected trust domain "domain2.test" for peer ID "spiffe://domain2.test/workload": expected trust domain "domain1.test"`)
 }

--- a/spiffe/tls_verify_test.go
+++ b/spiffe/tls_verify_test.go
@@ -64,7 +64,7 @@ func TestVerifyPeerCertificate(t *testing.T) {
 			chain:  peer1,
 			roots:  roots1,
 			expect: ExpectPeer("spiffe://domain2.test/workload"),
-			err:    `unexpected peer ID "spiffe://domain1.test/workload"`,
+			err:    `unexpected peer ID "spiffe://domain1.test/workload": expected "spiffe://domain2.test/workload"`,
 		},
 		{
 			name:   "bad peer id",


### PR DESCRIPTION
I was working through the examples and found it useful for the logs to just print what it *was* expecting.

I'm not super sure about the security implications of this, but it sure is useful for debugging.

If you think it is a good idea, I'll amend it with updates to the v2 versions as well.