### PR TITLE
Add link to v2 spiffe-jwt-using-proxy code sample set

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,12 @@
+# Deprecation Warning
+
+__NOTE:__ The code samples in this directory were written for the [v1 version](../README.md) of the go-spiffe library, which will be deprecated soon.
+
+We recommend that you write new code using the `v2` go-spiffe module. See [go-spiffe (v2) Examples](../v2/examples) for code samples written for the `v2` go-spiffe module. See [go-spiffe (v2)](../v2) for general information about the `v2` go-spiffe module.
+
 # Examples
 
-This section contains a set of standalone examples that demonstrate different use cases for the go-spiffe library.
+This section contains a set of standalone examples that demonstrate different use cases for the `v1` go-spiffe library.
 
 ## Use cases
 

--- a/v2/examples/README.md
+++ b/v2/examples/README.md
@@ -12,4 +12,6 @@ This section contains a set of standalone examples that demonstrate different us
 
 - [HTTP over mTLS](spiffe-http/README.md): _Send HTTP requests between workloads over mTLS using automatically rotated X.509 SVIDs obtained from the SPIFFE Workload API._ 
 
-- [HTTP over TLS with JWT](spiffe-jwt/README.md): _Send http requests between workload over a TLS + JWT authentication using automatically rotated X.509 SVIDs and JWT SVIDs from the SPIFFE Workload API._
+- [HTTP over TLS with JWT and X.509 SVIDs](spiffe-jwt/README.md): _Send HTTP requests between workload over a TLS + JWT authentication using automatically rotated X.509 SVIDs and JWT SVIDs from the SPIFFE Workload API._
+
+- [HTTP over TLS with JWT SVIDs only](spiffe-jwt-using-proxy/README.md): _Authenticate client workloads to the server using JWT-SVIDs sent over TLS-encrypted HTTP connections to handle environments in which a proxy or load balancer would prevent the transmission of X.509-SVIDs over mTLS._

--- a/v2/examples/spiffe-jwt/README.md
+++ b/v2/examples/spiffe-jwt/README.md
@@ -1,6 +1,6 @@
 # HTTP over TLS with JWT
 
-This example shows how two services using HTTP can communicate using TLS with the server presenting an X509 SVID and expecting a client to authenticate with a JWT-SVID. The SVIDs are retrieve, and authentication is accomplished, via the SPIFFE Workload API.
+This example shows how two services using HTTP can communicate using TLS with the server presenting an X509 SVID and expecting a client to authenticate with a JWT-SVID. The SVIDs are retrieved, and authentication is accomplished, via the SPIFFE Workload API.
 
 The **HTTP server** creates a [workloadapi.X509Source](https://pkg.go.dev/github.com/spiffe/go-spiffe/v2/workloadapi?tab=doc#X509Source).
 
@@ -95,7 +95,7 @@ go build
 
 ## Running
 This example assumes the following preconditions:
-- There is a SPIRE server and agent up and running.
+- There is a SPIRE Server and Agent up and running.
 - There is a Unix workload attestor configured.
 - The trust domain is `example.org`
 - The agent SPIFFE ID is `spiffe://example.org/host`.
@@ -132,7 +132,7 @@ sudo -u client-workload ./client
 
 The server should display a log `Request received` and client `Success!!!`
 
-To demonstrate a failure, an alternate audience value can be used. The server is expecting it's own SPIFFE ID as the audience value and will reject the token if it doesn't match.
+To demonstrate a failure, an alternate audience value can be used. The server is expecting its own SPIFFE ID as the audience value and will reject the token if it doesn't match.
 
 ```
 sudo -u client-workload ./client spiffe://example.org/some-other-server


### PR DESCRIPTION
Also:
* Add deprecation warning to v1 code sample README and links to v2 info
* Miscellaneous minor edits

Signed-off-by: Steve Anderson <steve.anderson@hpe.com>