### PR TITLE
tlsconfig trace implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# go-spiffe (v1) library [![GoDoc](https://godoc.org/github.com/spiffe/go-spiffe?status.svg)](https://godoc.org/github.com/spiffe/go-spiffe)
-
 # Deprecation Warning
 
 __NOTE:__ This version of the library will be deprecated soon.
 
-The new [v2](./v2) module is currently in alpha release and published under
+The [v2](./v2) module is in **beta** and published under
 `github.com/spiffe/go-spiffe/v2`, following go module guidelines.
 
-New code should consider using the `v2` module.
+**New code should strongly consider using the `v2` module.**
 
 See the [v2 README](./v2) for more details.
+
+# go-spiffe (v1) library [![GoDoc](https://godoc.org/github.com/spiffe/go-spiffe?status.svg)](https://godoc.org/github.com/spiffe/go-spiffe)
 
 ## Overview
 

--- a/spiffe/expect.go
+++ b/spiffe/expect.go
@@ -22,7 +22,7 @@ func ExpectAnyPeer() ExpectPeerFunc {
 func ExpectPeer(expectedID string) ExpectPeerFunc {
 	return func(peerID string, _ [][]*x509.Certificate) error {
 		if peerID != expectedID {
-			return fmt.Errorf("unexpected peer ID %q", peerID)
+			return fmt.Errorf("unexpected peer ID %q: expected %q", peerID, expectedID)
 		}
 		return nil
 	}
@@ -36,7 +36,7 @@ func ExpectPeers(expectedIDs ...string) ExpectPeerFunc {
 	}
 	return func(peerID string, _ [][]*x509.Certificate) error {
 		if _, ok := m[peerID]; !ok {
-			return fmt.Errorf("unexpected peer ID %q", peerID)
+			return fmt.Errorf("unexpected peer ID %q: expected one of %q", peerID, expectedIDs)
 		}
 		return nil
 	}
@@ -47,7 +47,7 @@ func ExpectPeers(expectedIDs ...string) ExpectPeerFunc {
 func ExpectPeerInDomain(expectedDomain string) ExpectPeerFunc {
 	return func(peerID string, _ [][]*x509.Certificate) error {
 		if domain := getPeerTrustDomain(peerID); domain != expectedDomain {
-			return fmt.Errorf("unexpected peer trust domain %q", domain)
+			return fmt.Errorf("unexpected trust domain %q for peer ID %q: expected trust domain %q", domain, peerID, expectedDomain)
 		}
 		return nil
 	}

--- a/spiffe/expect_test.go
+++ b/spiffe/expect_test.go
@@ -18,7 +18,7 @@ func TestExpectPeer(t *testing.T) {
 	expect := ExpectPeer("spiffe://domain.test/workload1")
 	assert.NoError(t, expect("spiffe://domain.test/workload1", nil))
 	assert.EqualError(t, expect("spiffe://domain.test/workload2", nil),
-		`unexpected peer ID "spiffe://domain.test/workload2"`)
+		`unexpected peer ID "spiffe://domain.test/workload2": expected "spiffe://domain.test/workload1"`)
 }
 
 func TestExpectPeers(t *testing.T) {
@@ -26,12 +26,12 @@ func TestExpectPeers(t *testing.T) {
 	assert.NoError(t, expect("spiffe://domain.test/workload1", nil))
 	assert.NoError(t, expect("spiffe://domain.test/workload2", nil))
 	assert.EqualError(t, expect("spiffe://domain.test/workload3", nil),
-		`unexpected peer ID "spiffe://domain.test/workload3"`)
+		`unexpected peer ID "spiffe://domain.test/workload3": expected one of ["spiffe://domain.test/workload1" "spiffe://domain.test/workload2"]`)
 }
 
 func TestExpectPeerInDomain(t *testing.T) {
 	expect := ExpectPeerInDomain("domain1.test")
 	assert.NoError(t, expect("spiffe://domain1.test/workload", nil))
 	assert.EqualError(t, expect("spiffe://domain2.test/workload", nil),
-		`unexpected peer trust domain "domain2.test"`)
+		`unexpected trust domain "domain2.test" for peer ID "spiffe://domain2.test/workload": expected trust domain "domain1.test"`)
 }

--- a/spiffe/tls_verify_test.go
+++ b/spiffe/tls_verify_test.go
@@ -64,7 +64,7 @@ func TestVerifyPeerCertificate(t *testing.T) {
 			chain:  peer1,
 			roots:  roots1,
 			expect: ExpectPeer("spiffe://domain2.test/workload"),
-			err:    `unexpected peer ID "spiffe://domain1.test/workload"`,
+			err:    `unexpected peer ID "spiffe://domain1.test/workload": expected "spiffe://domain2.test/workload"`,
 		},
 		{
 			name:   "bad peer id",

--- a/v2/spiffetls/dial.go
+++ b/v2/spiffetls/dial.go
@@ -59,9 +59,9 @@ func DialWithMode(ctx context.Context, network, addr string, mode DialMode, opti
 	case tlsClientMode:
 		tlsconfig.HookTLSClientConfig(tlsConfig, m.bundle, m.authorizer)
 	case mtlsClientMode:
-		tlsconfig.HookMTLSClientConfig(tlsConfig, m.svid, m.bundle, m.authorizer)
+		tlsconfig.HookMTLSClientConfig(tlsConfig, m.svid, m.bundle, m.authorizer, opt.tlsoptions...)
 	case mtlsWebClientMode:
-		tlsconfig.HookMTLSWebClientConfig(tlsConfig, m.svid, m.roots)
+		tlsconfig.HookMTLSWebClientConfig(tlsConfig, m.svid, m.roots, opt.tlsoptions...)
 	default:
 		return nil, spiffetlsErr.New("unknown client mode: %v", m.mode)
 	}

--- a/v2/spiffetls/listen.go
+++ b/v2/spiffetls/listen.go
@@ -89,9 +89,9 @@ func NewListenerWithMode(ctx context.Context, inner net.Listener, mode ListenMod
 
 	switch m.mode {
 	case tlsServerMode:
-		tlsconfig.HookTLSServerConfig(tlsConfig, m.svid)
+		tlsconfig.HookTLSServerConfig(tlsConfig, m.svid, opt.tlsoptions...)
 	case mtlsServerMode:
-		tlsconfig.HookMTLSServerConfig(tlsConfig, m.svid, m.bundle, m.authorizer)
+		tlsconfig.HookMTLSServerConfig(tlsConfig, m.svid, m.bundle, m.authorizer, opt.tlsoptions...)
 	case mtlsWebServerMode:
 		tlsconfig.HookMTLSWebServerConfig(tlsConfig, m.cert, m.bundle, m.authorizer)
 	default:

--- a/v2/spiffetls/option.go
+++ b/v2/spiffetls/option.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"net"
 
+	"github.com/spiffe/go-spiffe/v2/spiffetls/tlsconfig"
 	"github.com/zeebo/errs"
 )
 
@@ -23,12 +24,14 @@ func (fn dialOption) apply(c *dialConfig) {
 type dialConfig struct {
 	baseTLSConf *tls.Config
 	dialer      *net.Dialer
+	tlsoptions  []tlsconfig.Option
 }
 
 type listenOption func(*listenConfig)
 
 type listenConfig struct {
 	baseTLSConf *tls.Config
+	tlsoptions  []tlsconfig.Option
 }
 
 func (fn listenOption) apply(c *listenConfig) {
@@ -41,6 +44,13 @@ func (fn listenOption) apply(c *listenConfig) {
 func WithDialTLSConfigBase(base *tls.Config) DialOption {
 	return dialOption(func(c *dialConfig) {
 		c.baseTLSConf = base
+	})
+}
+
+// WithDialTLSOptions provides options to use for the TLS config.
+func WithDialTLSOptions(opts ...tlsconfig.Option) DialOption {
+	return dialOption(func(c *dialConfig) {
+		c.tlsoptions = opts
 	})
 }
 
@@ -63,5 +73,12 @@ type ListenOption interface {
 func WithListenTLSConfigBase(base *tls.Config) ListenOption {
 	return listenOption(func(c *listenConfig) {
 		c.baseTLSConf = base
+	})
+}
+
+// WithListenTLSOptions provides options to use when doing Server mTLS.
+func WithListenTLSOptions(opts ...tlsconfig.Option) ListenOption {
+	return listenOption(func(c *listenConfig) {
+		c.tlsoptions = opts
 	})
 }

--- a/v2/spiffetls/tlsconfig/trace.go
+++ b/v2/spiffetls/tlsconfig/trace.go
@@ -1,0 +1,18 @@
+package tlsconfig
+
+import (
+	"crypto/tls"
+)
+
+// GotCertificateInfo provides err and TLS certificate info to Trace
+type GotCertificateInfo struct {
+	Cert *tls.Certificate
+	Err  error
+}
+
+// Trace is the interface to define what functions are triggered when functions
+// in tlsconfig are called
+type Trace struct {
+	GetCertificate func() interface{}
+	GotCertificate func(interface{}, GotCertificateInfo)
+}


### PR DESCRIPTION
This is an implementation of TLSConfig hooks scoped just to `getTLSCertificate`.

cc https://github.com/spiffe/go-spiffe/issues/149