### PR TITLE
Add low-level grpccredentials package

### DIFF
--- a/v2/examples/spiffe-grpc/client/main.go
+++ b/v2/examples/spiffe-grpc/client/main.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"log"
 
+	"github.com/spiffe/go-spiffe/v2/spiffegrpc/grpccredentials"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/go-spiffe/v2/spiffetls/tlsconfig"
 	"github.com/spiffe/go-spiffe/v2/workloadapi"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 	pb "google.golang.org/grpc/examples/helloworld/helloworld"
 )
 
@@ -30,9 +30,10 @@ func main() {
 	// Allowed SPIFFE ID
 	serverID := spiffeid.Must("example.org", "server")
 
-	// Create a `tls.Config` to allow mTLS connections, and verify that presented certificate has SPIFFE ID `spiffe://example.org/server`
-	tlsConfig := tlsconfig.MTLSClientConfig(source, source, tlsconfig.AuthorizeID(serverID))
-	conn, err := grpc.DialContext(ctx, "localhost:50051", grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
+	// Dial the server with credentials that do mTLS and verify that presented certificate has SPIFFE ID `spiffe://example.org/server`
+	conn, err := grpc.DialContext(ctx, "localhost:50051", grpc.WithTransportCredentials(
+		grpccredentials.MTLSClientCredentials(source, source, tlsconfig.AuthorizeID(serverID)),
+	))
 	if err != nil {
 		log.Fatalf("Error creating dial: %v", err)
 	}

--- a/v2/examples/spiffe-grpc/server/main.go
+++ b/v2/examples/spiffe-grpc/server/main.go
@@ -5,11 +5,10 @@ import (
 	"log"
 	"net"
 
+	"github.com/spiffe/go-spiffe/v2/spiffegrpc/grpccredentials"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
-	"github.com/spiffe/go-spiffe/v2/spiffetls/tlsconfig"
 	"github.com/spiffe/go-spiffe/v2/workloadapi"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 	pb "google.golang.org/grpc/examples/helloworld/helloworld"
 )
 
@@ -41,9 +40,10 @@ func main() {
 	// Allowed SPIFFE ID
 	clientID := spiffeid.Must("example.org", "client")
 
-	// Create a `tls.Config` to allow mTLS connections, and verify that presented certificate has SPIFFE ID `spiffe://example.org/client`
-	tlsConfig := tlsconfig.MTLSServerConfig(source, source, tlsconfig.AuthorizeID(clientID))
-	s := grpc.NewServer(grpc.Creds(credentials.NewTLS(tlsConfig)))
+	// Create a server with credentials that do mTLS and verify that the presented certificate has SPIFFE ID `spiffe://example.org/client`
+	s := grpc.NewServer(grpc.Creds(
+		grpccredentials.MTLSServerCredentials(source, source, grpccredentials.AuthorizeID(clientID)),
+	))
 
 	lis, err := net.Listen("tcp", "127.0.0.1:50051")
 	if err != nil {

--- a/v2/spiffegrpc/grpccredentials/credentials.go
+++ b/v2/spiffegrpc/grpccredentials/credentials.go
@@ -1,0 +1,130 @@
+package grpccredentials
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net"
+
+	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/go-spiffe/v2/spiffetls/tlsconfig"
+	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+)
+
+// TLSClientCredentials returns TLS credentials which verify and authorize
+// the server X509-SVID.
+func TLSClientCredentials(bundle x509bundle.Source, authorizer tlsconfig.Authorizer, opts ...tlsconfig.Option) credentials.TransportCredentials {
+	return credentialsWrapper{c: credentials.NewTLS(tlsconfig.TLSClientConfig(bundle, authorizer, opts...)), expectPeerID: true}
+}
+
+// MTLSClientCredentials returns TLS credentials which present an X509-SVID
+// to the server and verifies and authorizes the server X509-SVID.
+func MTLSClientCredentials(svid x509svid.Source, bundle x509bundle.Source, authorizer tlsconfig.Authorizer, opts ...tlsconfig.Option) credentials.TransportCredentials {
+	return credentialsWrapper{c: credentials.NewTLS(tlsconfig.MTLSClientConfig(svid, bundle, authorizer, opts...)), expectPeerID: true}
+}
+
+// MTLSWebClientCredentials returns TLS credentials which present an X509-SVID
+// to the server and verifies the server certificate using provided roots (or
+// the system roots if nil).
+func MTLSWebClientCredentials(svid x509svid.Source, roots *x509.CertPool, opts ...tlsconfig.Option) credentials.TransportCredentials {
+	return credentialsWrapper{c: credentials.NewTLS(tlsconfig.MTLSWebClientConfig(svid, roots, opts...)), expectPeerID: false}
+}
+
+// TLSServerCredentials returns TLS credentials which present an X509-SVID
+// to the client and does not require or verify client certificates.
+func TLSServerCredentials(svid x509svid.Source, opts ...tlsconfig.Option) credentials.TransportCredentials {
+	return credentialsWrapper{c: credentials.NewTLS(tlsconfig.TLSServerConfig(svid, opts...)), expectPeerID: false}
+}
+
+// MTLSServerCredentials returns TLS credentials which present an X509-SVID
+// to the client and requires, verifies, and authorizes client X509-SVIDs.
+func MTLSServerCredentials(svid x509svid.Source, bundle x509bundle.Source, authorizer tlsconfig.Authorizer, opts ...tlsconfig.Option) credentials.TransportCredentials {
+	return credentialsWrapper{c: credentials.NewTLS(tlsconfig.MTLSServerConfig(svid, bundle, authorizer, opts...)), expectPeerID: true}
+}
+
+// MTLSWebServerCredentials returns TLS credentials which present a web
+// server certificate to the client and requires, verifies, and authorizes
+// client X509-SVIDs.
+func MTLSWebServerCredentials(cert *tls.Certificate, bundle x509bundle.Source, authorizer tlsconfig.Authorizer, opts ...tlsconfig.Option) credentials.TransportCredentials {
+	return credentialsWrapper{c: credentials.NewTLS(tlsconfig.MTLSWebServerConfig(cert, bundle, authorizer, opts...)), expectPeerID: true}
+}
+
+// PeerIDFromContext returns the SPIFFE ID from the peer information on the
+// context. If the peer does not have a SPIFFE ID, or the credentials for the
+// connection were not provided by this package, the function returns false.
+func PeerIDFromContext(ctx context.Context) (spiffeid.ID, bool) {
+	p, ok := peer.FromContext(ctx)
+	if !ok {
+		return spiffeid.ID{}, false
+	}
+	return PeerIDFromPeer(p)
+}
+
+// PeerIDFromPeer returns the SPIFFE ID for the peer information on the
+// context. If the peer does not have a SPIFFE ID, or the credentials for the
+// connection were not provided by this package, the function returns false.
+func PeerIDFromPeer(p *peer.Peer) (spiffeid.ID, bool) {
+	authInfo, ok := p.AuthInfo.(authInfoWrapper)
+	if !ok {
+		return spiffeid.ID{}, false
+	}
+	return authInfo.PeerID()
+}
+
+type credentialsWrapper struct {
+	c            credentials.TransportCredentials
+	expectPeerID bool
+}
+
+func (w credentialsWrapper) ClientHandshake(ctx context.Context, authority string, rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+	return w.wrapHandshake(w.c.ClientHandshake(ctx, authority, rawConn))
+}
+
+func (w credentialsWrapper) ServerHandshake(rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+	return w.wrapHandshake(w.c.ServerHandshake(rawConn))
+}
+
+func (w credentialsWrapper) wrapHandshake(conn net.Conn, authInfo credentials.AuthInfo, handshakeErr error) (net.Conn, credentials.AuthInfo, error) {
+	if handshakeErr != nil {
+		return nil, nil, handshakeErr
+	}
+	var peerID spiffeid.ID
+	if tlsInfo, ok := authInfo.(credentials.TLSInfo); ok && w.expectPeerID {
+		var err error
+		peerID, err = spiffeid.FromString(tlsInfo.SPIFFEID.String())
+		if err != nil {
+			conn.Close()
+			return nil, nil, fmt.Errorf("invalid peer SPIFFE ID: %w", err)
+		}
+	}
+	return conn, authInfoWrapper{AuthInfo: authInfo, peerID: peerID}, nil
+}
+
+func (w credentialsWrapper) Info() credentials.ProtocolInfo {
+	return w.c.Info()
+}
+
+func (w credentialsWrapper) Clone() credentials.TransportCredentials {
+	return credentialsWrapper{
+		c:            w.c.Clone(),
+		expectPeerID: w.expectPeerID,
+	}
+}
+
+func (w credentialsWrapper) OverrideServerName(serverName string) error {
+	return w.c.OverrideServerName(serverName)
+}
+
+type authInfoWrapper struct {
+	credentials.AuthInfo
+
+	peerID spiffeid.ID
+}
+
+func (w authInfoWrapper) PeerID() (spiffeid.ID, bool) {
+	return w.peerID, w.peerID.IsZero()
+}

--- a/v2/spiffegrpc/grpccredentials/credentials_test.go
+++ b/v2/spiffegrpc/grpccredentials/credentials_test.go
@@ -1,0 +1,179 @@
+package grpccredentials_test
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/internal/test"
+	"github.com/spiffe/go-spiffe/v2/spiffegrpc/grpccredentials"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/go-spiffe/v2/spiffetls/tlsconfig"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/examples/helloworld/helloworld"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+)
+
+func TestCredentials(t *testing.T) {
+	webRoots, webCert := test.CreateWebCredentials(t)
+
+	td := spiffeid.RequireTrustDomainFromString("domain.test")
+	ca := test.NewCA(t, td)
+	bundle := ca.Bundle()
+	serverSVID := ca.CreateX509SVID(td.NewID("/server"))
+	clientSVID := ca.CreateX509SVID(td.NewID("/client"))
+	serverID := serverSVID.ID.String()
+	clientID := clientSVID.ID.String()
+
+	serverMTLS := grpccredentials.MTLSServerCredentials(serverSVID, bundle, tlsconfig.AuthorizeAny())
+	clientMTLS := grpccredentials.MTLSClientCredentials(clientSVID, bundle, tlsconfig.AuthorizeAny())
+	serverTLS := grpccredentials.TLSServerCredentials(serverSVID)
+	clientTLS := grpccredentials.TLSClientCredentials(bundle, tlsconfig.AuthorizeAny())
+	serverWeb := grpccredentials.MTLSWebServerCredentials(webCert, bundle, tlsconfig.AuthorizeAny())
+	clientWeb := grpccredentials.MTLSWebClientCredentials(clientSVID, webRoots)
+
+	t.Run("mTLS to mTLS", func(t *testing.T) {
+		// Handshake will succeed.
+		testCredentials(t, clientMTLS, serverMTLS, expectResult{
+			Code:     codes.OK,
+			ServerID: serverID,
+			ClientID: clientID,
+		})
+	})
+
+	t.Run("TLS to mTLS", func(t *testing.T) {
+		// Handshake will fail since server requires client SVID
+		testCredentials(t, clientTLS, serverMTLS, expectResult{
+			Code:    codes.Unavailable,
+			Message: "connection closed",
+		})
+	})
+
+	t.Run("Web to mTLS", func(t *testing.T) {
+		// Handshake will fail because client is doing hostname validation
+		// against a server SVID
+		testCredentials(t, clientWeb, serverMTLS, expectResult{
+			Code:    codes.Unavailable,
+			Message: `connection error: desc = "transport: authentication handshake failed: x509: cannot validate certificate for 127.0.0.1 because it doesn't contain any IP SANs"`,
+		})
+	})
+
+	t.Run("mTLS to TLS", func(t *testing.T) {
+		// Handshake will succeed, but the server won't pick up (or validate)
+		// the client SVID.
+		testCredentials(t, clientMTLS, serverTLS, expectResult{
+			Code:     codes.OK,
+			ServerID: serverID,
+			ClientID: "",
+		})
+	})
+
+	t.Run("TLS to TLS", func(t *testing.T) {
+		// Handshake will succeed, but the server won't pick up (or validate)
+		// the client SVID.
+		testCredentials(t, clientTLS, serverTLS, expectResult{
+			Code:     codes.OK,
+			ServerID: serverID,
+			ClientID: "",
+		})
+	})
+
+	t.Run("Web to TLS", func(t *testing.T) {
+		// Handshake will fail because client is doing hostname validation
+		// against a server SVID
+		testCredentials(t, clientWeb, serverTLS, expectResult{
+			Code:    codes.Unavailable,
+			Message: `connection error: desc = "transport: authentication handshake failed: x509: cannot validate certificate for 127.0.0.1 because it doesn't contain any IP SANs"`,
+		})
+	})
+
+	t.Run("mTLS to Web", func(t *testing.T) {
+		// Handshake will fail because client expects server SVID
+		testCredentials(t, clientMTLS, serverWeb, expectResult{
+			Code:    codes.Unavailable,
+			Message: `connection error: desc = "transport: authentication handshake failed: x509svid: could not get leaf SPIFFE ID: certificate contains no URI SAN"`,
+		})
+	})
+
+	t.Run("TLS to Web", func(t *testing.T) {
+		// Handshake will fail because client expects server SVID
+		testCredentials(t, clientTLS, serverWeb, expectResult{
+			Code:    codes.Unavailable,
+			Message: `connection error: desc = "transport: authentication handshake failed: x509svid: could not get leaf SPIFFE ID: certificate contains no URI SAN"`,
+		})
+	})
+
+	t.Run("Web to Web", func(t *testing.T) {
+		// Handshake will succeed, but the server won't pick up (or validate)
+		// the client SVID.
+		testCredentials(t, clientWeb, serverWeb, expectResult{
+			Code:     codes.OK,
+			ServerID: "", // No server SVID for web server
+			ClientID: clientID,
+		})
+	})
+}
+
+type expectResult struct {
+	Code     codes.Code
+	Message  string
+	ClientID string
+	ServerID string
+}
+
+func testCredentials(t *testing.T, clientCreds, serverCreds credentials.TransportCredentials, expect expectResult) {
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	server := grpc.NewServer(grpc.Creds(serverCreds))
+	defer server.Stop()
+
+	helloworld.RegisterGreeterServer(server, greeterServer{})
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		server.Serve(listener)
+	}()
+
+	conn, err := grpc.DialContext(ctx, listener.Addr().String(), grpc.WithTransportCredentials(clientCreds))
+	require.NoError(t, err)
+	defer conn.Close()
+
+	clientPeer := new(peer.Peer)
+	var clientID string
+	resp, err := helloworld.NewGreeterClient(conn).SayHello(ctx, &helloworld.HelloRequest{}, grpc.Peer(clientPeer))
+	if err == nil {
+		clientID = resp.Message
+	}
+
+	st := status.Convert(err)
+	serverID, _ := grpccredentials.PeerIDFromPeer(clientPeer)
+
+	assert.Equal(t, expect, expectResult{
+		Code:     st.Code(),
+		Message:  st.Message(),
+		ClientID: clientID,
+		ServerID: serverID.String(),
+	})
+}
+
+type greeterServer struct {
+	helloworld.UnimplementedGreeterServer
+}
+
+func (s greeterServer) SayHello(ctx context.Context, in *helloworld.HelloRequest) (*helloworld.HelloReply, error) {
+	peerID, _ := grpccredentials.PeerIDFromContext(ctx)
+	return &helloworld.HelloReply{Message: peerID.String()}, nil
+}


### PR DESCRIPTION
This adds some low-level helpers for creating grpc credentials. It does not go so far as to define higher-level grpc helpers for dialing and creating servers and the like, but does place the package underneath a placeholder spiffegrpc directory that will hold the high level helpers (similar to how the spiffetls high-level holds the tlsconfig low-level package).

The helpers rely on the tlsconfig package authorizer and options types. I thought that was appropriate for a low-level package, instead of duplicating or aliasing the types and functions from tlsconfig...