### PR TITLE
Fix no error return in getTLSCertificate

### DIFF
--- a/v2/spiffetls/tlsconfig/config.go
+++ b/v2/spiffetls/tlsconfig/config.go
@@ -214,8 +214,8 @@ func getTLSCertificate(svid x509svid.Source, trace Trace) (*tls.Certificate, err
 	if err != nil {
 		if trace.GotCertificate != nil {
 			trace.GotCertificate(traceVal, GotCertificateInfo{Err: err})
-			return nil, err
 		}
+		return nil, err
 	}
 
 	cert := &tls.Certificate{


### PR DESCRIPTION
Fix no error return in getTLSCertificate when trace function is not configured

Change-Id: I1ba680638e61006f48651c0c3b34c5a06e4e9399

Fixes issue #174 