### PR TITLE
Implement text marshaling for ID/TrustDomain types

### DIFF
--- a/v2/spiffeid/id.go
+++ b/v2/spiffeid/id.go
@@ -226,3 +226,27 @@ func (id ID) ReplaceSegments(segments ...string) (ID, error) {
 	id.path = path
 	return id, nil
 }
+
+// MarshalText returns a text representation of the ID. If the ID is the zero
+// value, nil is returned.
+func (id ID) MarshalText() ([]byte, error) {
+	if id.IsZero() {
+		return nil, nil
+	}
+	return []byte(id.String()), nil
+}
+
+// UnmarshalText decodes a text representation of the ID. If the text is empty,
+// the ID is set to the zero value.
+func (id *ID) UnmarshalText(text []byte) error {
+	if len(text) == 0 {
+		*id = ID{}
+		return nil
+	}
+	unmarshaled, err := FromString(string(text))
+	if err != nil {
+		return err
+	}
+	*id = unmarshaled
+	return nil
+}

--- a/v2/spiffeid/trustdomain.go
+++ b/v2/spiffeid/trustdomain.go
@@ -81,6 +81,31 @@ func (td TrustDomain) Compare(other TrustDomain) int {
 	return strings.Compare(td.name, other.name)
 }
 
+// MarshalText returns a text representation of the trust domain. If the trust
+// domain is the zero value, nil is returned.
+func (td TrustDomain) MarshalText() ([]byte, error) {
+	if td.IsZero() {
+		return nil, nil
+	}
+	return []byte(td.String()), nil
+}
+
+// UnmarshalText decodes a text representation of the trust domain. If the text
+// is empty, the trust domain is set to the zero value.
+func (td *TrustDomain) UnmarshalText(text []byte) error {
+	if len(text) == 0 {
+		*td = TrustDomain{}
+		return nil
+	}
+
+	unmarshaled, err := TrustDomainFromString(string(text))
+	if err != nil {
+		return err
+	}
+	*td = unmarshaled
+	return nil
+}
+
 func isValidTrustDomainChar(c uint8) bool {
 	switch {
 	case c >= 'a' && c <= 'z':


### PR DESCRIPTION
This allows the spiffeid.ID and spiffeid.TrustDomain types to be conveniently used with the standard library text encoding packages (e.g. `encoding/json`, `encoding/xml`).