### PR TITLE
Rearrange tlsconfig trace args

### DIFF
--- a/v2/spiffetls/tlsconfig/config.go
+++ b/v2/spiffetls/tlsconfig/config.go
@@ -207,13 +207,13 @@ func WrapVerifyPeerCertificate(wrapped func([][]byte, [][]*x509.Certificate) err
 func getTLSCertificate(svid x509svid.Source, trace Trace) (*tls.Certificate, error) {
 	var traceVal interface{}
 	if trace.GetCertificate != nil {
-		traceVal = trace.GetCertificate()
+		traceVal = trace.GetCertificate(GetCertificateInfo{})
 	}
 
 	s, err := svid.GetX509SVID()
 	if err != nil {
 		if trace.GotCertificate != nil {
-			trace.GotCertificate(traceVal, GotCertificateInfo{Err: err})
+			trace.GotCertificate(GotCertificateInfo{Err: err}, traceVal)
 		}
 		return nil, err
 	}
@@ -228,7 +228,7 @@ func getTLSCertificate(svid x509svid.Source, trace Trace) (*tls.Certificate, err
 	}
 
 	if trace.GotCertificate != nil {
-		trace.GotCertificate(traceVal, GotCertificateInfo{Cert: cert})
+		trace.GotCertificate(GotCertificateInfo{Cert: cert}, traceVal)
 	}
 
 	return cert, nil

--- a/v2/spiffetls/tlsconfig/config_test.go
+++ b/v2/spiffetls/tlsconfig/config_test.go
@@ -21,11 +21,11 @@ import (
 )
 
 var localTrace = tlsconfig.Trace{
-	GetCertificate: func() interface{} {
+	GetCertificate: func(tlsconfig.GetCertificateInfo) interface{} {
 		fmt.Printf("got start of GetTLSCertificate\n")
 		return nil
 	},
-	GotCertificate: func(interface{}, tlsconfig.GotCertificateInfo) {
+	GotCertificate: func(tlsconfig.GotCertificateInfo, interface{}) {
 		fmt.Printf("got end of GetTLSCertificate\n")
 	},
 }
@@ -263,13 +263,13 @@ func TestHookMTLSWebServerConfig(t *testing.T) {
 
 func hookedTracer(onGetCertificate, onGotCertificate func()) tlsconfig.Trace {
 	return tlsconfig.Trace{
-		GetCertificate: func() interface{} {
+		GetCertificate: func(tlsconfig.GetCertificateInfo) interface{} {
 			if onGetCertificate != nil {
 				onGetCertificate()
 			}
 			return nil
 		},
-		GotCertificate: func(interface{}, tlsconfig.GotCertificateInfo) {
+		GotCertificate: func(tlsconfig.GotCertificateInfo, interface{}) {
 			if onGotCertificate != nil {
 				onGotCertificate()
 			}

--- a/v2/spiffetls/tlsconfig/trace.go
+++ b/v2/spiffetls/tlsconfig/trace.go
@@ -4,6 +4,10 @@ import (
 	"crypto/tls"
 )
 
+// GetCertificateInfo is an empty placeholder for future expansion
+type GetCertificateInfo struct {
+}
+
 // GotCertificateInfo provides err and TLS certificate info to Trace
 type GotCertificateInfo struct {
 	Cert *tls.Certificate
@@ -13,6 +17,6 @@ type GotCertificateInfo struct {
 // Trace is the interface to define what functions are triggered when functions
 // in tlsconfig are called
 type Trace struct {
-	GetCertificate func() interface{}
-	GotCertificate func(interface{}, GotCertificateInfo)
+	GetCertificate func(GetCertificateInfo) interface{}
+	GotCertificate func(GotCertificateInfo, interface{})
 }


### PR DESCRIPTION
Allows for future expansion and aligns params for consistency

Signed-off-by: Andrew Harding <aharding@vmware.com>