### PR TITLE
Relax test assertions

### DIFF
--- a/v2/spiffetls/spiffetls_test.go
+++ b/v2/spiffetls/spiffetls_test.go
@@ -436,10 +436,10 @@ func TestClose(t *testing.T) {
 
 	// If the connection was really closed, this should fail
 	_, err = conn.Write([]byte(dataString))
-	require.EqualError(t, err, "tls: use of closed connection")
+	require.Error(t, err)
 
 	// Connection has been closed already, expect error
-	require.EqualError(t, conn.Close(), "spiffetls: unable to close TLS connection: tls: use of closed connection")
+	require.Error(t, conn.Close())
 
 	// Close listener
 	require.NoError(t, listener.Close())
@@ -449,7 +449,7 @@ func TestClose(t *testing.T) {
 	require.Error(t, err)
 
 	// Listener has been closed already, expect error
-	require.Contains(t, listener.Close().Error(), "use of closed network connection")
+	require.Error(t, listener.Close())
 }
 
 func setWorkloadAPIResponse(ca *test.CA, s *fakeworkloadapi.WorkloadAPI, spiffeID spiffeid.ID) {


### PR DESCRIPTION
The current assertions are too coupled to the exact error message
produced by the Go net package internals, which can vary between
versions and platforms.

We don't really need this strong of an assertion. All we need to know is
that the Close() method was wired through appropriately.

Signed-off-by: Andrew Harding <aharding@vmware.com>