### PR TITLE
Support Named Pipes in gRPC target strings

### DIFF
--- a/v2/internal/test/fakeworkloadapi/workload_api.go
+++ b/v2/internal/test/fakeworkloadapi/workload_api.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net"
 	"sync"
 	"testing"
 
@@ -51,7 +50,7 @@ func New(tb testing.TB) *WorkloadAPI {
 		x509BundlesChans: make(map[chan *workload.X509BundlesResponse]struct{}),
 	}
 
-	listener, err := net.Listen("tcp", "localhost:0")
+	listener, err := newListener()
 	require.NoError(tb, err)
 
 	server := grpc.NewServer()
@@ -63,7 +62,7 @@ func New(tb testing.TB) *WorkloadAPI {
 		_ = server.Serve(listener)
 	}()
 
-	w.addr = fmt.Sprintf("%s://%s", listener.Addr().Network(), listener.Addr().String())
+	w.addr = getTargetName(listener.Addr())
 	tb.Logf("WorkloadAPI address: %s", w.addr)
 	w.server = server
 	return w

--- a/v2/internal/test/fakeworkloadapi/workload_api_posix.go
+++ b/v2/internal/test/fakeworkloadapi/workload_api_posix.go
@@ -1,0 +1,17 @@
+//go:build !windows
+// +build !windows
+
+package fakeworkloadapi
+
+import (
+	"fmt"
+	"net"
+)
+
+func newListener() (net.Listener, error) {
+	return net.Listen("tcp", "localhost:0")
+}
+
+func getTargetName(addr net.Addr) string {
+	return fmt.Sprintf("%s://%s", addr.Network(), addr.String())
+}

--- a/v2/spiffetls/spiffetls_posix_test.go
+++ b/v2/spiffetls/spiffetls_posix_test.go
@@ -1,0 +1,21 @@
+//go:build !windows
+// +build !windows
+
+package spiffetls_test
+
+import (
+	"github.com/spiffe/go-spiffe/v2/spiffetls"
+	"github.com/spiffe/go-spiffe/v2/spiffetls/tlsconfig"
+)
+
+func listenAndDialCasesOS() []listenAndDialCase {
+	return []listenAndDialCase{
+		{
+			name:             "Wrong workload API server socket",
+			dialMode:         spiffetls.TLSClient(tlsconfig.AuthorizeID(serverID)),
+			defaultWlAPIAddr: "wrong-socket-path",
+			dialErr:          "spiffetls: cannot create X.509 source: workload endpoint socket URI must have a \"tcp\" or \"unix\" scheme",
+			listenErr:        "spiffetls: cannot create X.509 source: workload endpoint socket URI must have a \"tcp\" or \"unix\" scheme",
+		},
+	}
+}

--- a/v2/spiffetls/spiffetls_test.go
+++ b/v2/spiffetls/spiffetls_test.go
@@ -49,6 +49,26 @@ type testEnv struct {
 	err          error
 }
 
+type listenAndDialCase struct {
+	name string
+
+	dialMode   spiffetls.DialMode
+	dialOption []spiffetls.DialOption
+
+	listenMode   spiffetls.ListenMode
+	listenOption []spiffetls.ListenOption
+
+	defaultWlAPIAddr    string
+	dialErr             string
+	listenErr           string
+	listenLAddr         string
+	listenProtocol      string
+	serverConnPeerIDErr string
+	clientConnPeerIDErr string
+	usesExternalDialer  bool
+	usesBaseTLSConfig   bool
+}
+
 func TestListenAndDial(t *testing.T) {
 	testEnv, cleanup := setupTestEnv(t)
 	defer cleanup()
@@ -67,33 +87,8 @@ func TestListenAndDial(t *testing.T) {
 	externalTLSConfBuffer := &bytes.Buffer{}
 
 	// Test Table
-	tests := []struct {
-		name string
-
-		dialMode   spiffetls.DialMode
-		dialOption []spiffetls.DialOption
-
-		listenMode   spiffetls.ListenMode
-		listenOption []spiffetls.ListenOption
-
-		defaultWlAPIAddr    string
-		dialErr             string
-		listenErr           string
-		listenLAddr         string
-		listenProtocol      string
-		serverConnPeerIDErr string
-		clientConnPeerIDErr string
-		usesExternalDialer  bool
-		usesBaseTLSConfig   bool
-	}{
+	tests := []listenAndDialCase{
 		// Failure Scenarios
-		{
-			name:             "Wrong workload API server socket",
-			dialMode:         spiffetls.TLSClient(tlsconfig.AuthorizeID(serverID)),
-			defaultWlAPIAddr: "wrong-socket-path",
-			dialErr:          "spiffetls: cannot create X.509 source: workload endpoint socket URI must have a tcp:// or unix:// scheme",
-			listenErr:        "spiffetls: cannot create X.509 source: workload endpoint socket URI must have a tcp:// or unix:// scheme",
-		},
 		{
 			name:             "No server listening",
 			dialMode:         spiffetls.TLSClient(tlsconfig.AuthorizeID(serverID)),
@@ -248,6 +243,7 @@ func TestListenAndDial(t *testing.T) {
 			clientConnPeerIDErr: "spiffetls: no URI SANs",
 		},
 	}
+	tests = append(tests, listenAndDialCasesOS()...)
 
 	for _, test := range tests {
 		test := test

--- a/v2/spiffetls/spiffetls_windows_test.go
+++ b/v2/spiffetls/spiffetls_windows_test.go
@@ -1,0 +1,21 @@
+//go:build windows
+// +build windows
+
+package spiffetls_test
+
+import (
+	"github.com/spiffe/go-spiffe/v2/spiffetls"
+	"github.com/spiffe/go-spiffe/v2/spiffetls/tlsconfig"
+)
+
+func listenAndDialCasesOS() []listenAndDialCase {
+	return []listenAndDialCase{
+		{
+			name:             "Wrong workload API server socket",
+			dialMode:         spiffetls.TLSClient(tlsconfig.AuthorizeID(serverID)),
+			defaultWlAPIAddr: "wrong-socket-path",
+			dialErr:          "spiffetls: cannot create X.509 source: workload endpoint socket URI must have a \"tcp\" or \"npipe\" scheme",
+			listenErr:        "spiffetls: cannot create X.509 source: workload endpoint socket URI must have a \"tcp\" or \"npipe\" scheme",
+		},
+	}
+}

--- a/v2/workloadapi/addr_posix.go
+++ b/v2/workloadapi/addr_posix.go
@@ -1,0 +1,34 @@
+//go:build !windows
+// +build !windows
+
+package workloadapi
+
+import (
+	"errors"
+	"net/url"
+)
+
+var (
+	ErrInvalidEndpointScheme = errors.New("workload endpoint socket URI must have a \"tcp\" or \"unix\" scheme")
+)
+
+func parseTargetFromURLAddrOS(u *url.URL) (string, error) {
+	switch u.Scheme {
+	case "unix":
+		switch {
+		case u.Opaque != "":
+			return "", errors.New("workload endpoint unix socket URI must not be opaque")
+		case u.User != nil:
+			return "", errors.New("workload endpoint unix socket URI must not include user info")
+		case u.Host == "" && u.Path == "":
+			return "", errors.New("workload endpoint unix socket URI must include a path")
+		case u.RawQuery != "":
+			return "", errors.New("workload endpoint unix socket URI must not include query values")
+		case u.Fragment != "":
+			return "", errors.New("workload endpoint unix socket URI must not include a fragment")
+		}
+		return u.String(), nil
+	default:
+		return "", ErrInvalidEndpointScheme
+	}
+}

--- a/v2/workloadapi/addr_posix_test.go
+++ b/v2/workloadapi/addr_posix_test.go
@@ -1,0 +1,33 @@
+//go:build !windows
+// +build !windows
+
+package workloadapi
+
+func validateAddressCasesOS() []validateAddressCase {
+	return []validateAddressCase{
+		{
+			addr: "unix:opaque",
+			err:  "workload endpoint unix socket URI must not be opaque",
+		},
+		{
+			addr: "unix://",
+			err:  "workload endpoint unix socket URI must include a path",
+		},
+		{
+			addr: "unix://foo?whatever",
+			err:  "workload endpoint unix socket URI must not include query values",
+		},
+		{
+			addr: "unix://foo#whatever",
+			err:  "workload endpoint unix socket URI must not include a fragment",
+		},
+		{
+			addr: "unix://john:doe@foo/path",
+			err:  "workload endpoint unix socket URI must not include user info",
+		},
+		{
+			addr: "unix://foo",
+			err:  "",
+		},
+	}
+}

--- a/v2/workloadapi/addr_windows.go
+++ b/v2/workloadapi/addr_windows.go
@@ -1,0 +1,33 @@
+//go:build windows
+// +build windows
+
+package workloadapi
+
+import (
+	"errors"
+	"net/url"
+)
+
+var (
+	ErrInvalidEndpointScheme = errors.New("workload endpoint socket URI must have a \"tcp\" or \"npipe\" scheme")
+)
+
+func parseTargetFromURLAddrOS(u *url.URL) (string, error) {
+	switch u.Scheme {
+	case "npipe":
+		switch {
+		case u.Opaque == "" && u.Host != "":
+			return "", errors.New("workload endpoint named pipe URI must be opaque")
+		case u.Opaque == "":
+			return "", errors.New("workload endpoint named pipe URI must include an opaque part")
+		case u.RawQuery != "":
+			return "", errors.New("workload endpoint named pipe URI must not include query values")
+		case u.Fragment != "":
+			return "", errors.New("workload endpoint named pipe URI must not include a fragment")
+		}
+
+		return namedPipeTarget(u.Opaque), nil
+	default:
+		return "", ErrInvalidEndpointScheme
+	}
+}

--- a/v2/workloadapi/addr_windows_test.go
+++ b/v2/workloadapi/addr_windows_test.go
@@ -1,0 +1,37 @@
+//go:build windows
+// +build windows
+
+package workloadapi
+
+func validateAddressCasesOS() []validateAddressCase {
+	return []validateAddressCase{
+		{
+			addr: "npipe:pipeName",
+			err:  "",
+		},
+		{
+			addr: "npipe:pipe/name",
+			err:  "",
+		},
+		{
+			addr: "npipe:pipe\\name",
+			err:  "",
+		},
+		{
+			addr: "npipe:",
+			err:  "workload endpoint named pipe URI must include an opaque part",
+		},
+		{
+			addr: "npipe://foo",
+			err:  "workload endpoint named pipe URI must be opaque",
+		},
+		{
+			addr: "npipe:pipeName?query",
+			err:  "workload endpoint named pipe URI must not include query values",
+		},
+		{
+			addr: "npipe:pipeName#fragment",
+			err:  "workload endpoint named pipe URI must not include a fragment",
+		},
+	}
+}

--- a/v2/workloadapi/client_posix.go
+++ b/v2/workloadapi/client_posix.go
@@ -24,6 +24,6 @@ func (c *Client) setAddress() error {
 	}
 
 	var err error
-	c.config.address, err = parseTargetFromAddr(c.config.address)
+	c.config.address, err = parseTargetFromStringAddr(c.config.address)
 	return err
 }

--- a/v2/workloadapi/client_windows.go
+++ b/v2/workloadapi/client_windows.go
@@ -6,6 +6,7 @@ package workloadapi
 import (
 	"errors"
 	"path/filepath"
+	"strings"
 
 	"github.com/Microsoft/go-winio"
 	"google.golang.org/grpc"
@@ -38,7 +39,13 @@ func (c *Client) setAddress() error {
 		}
 	}
 
-	c.config.address, err = parseTargetFromAddr(c.config.address)
+	if strings.HasPrefix(c.config.address, "npipe:") {
+		// Use the dialer to connect to named pipes only if the gRPC target
+		// string has the "npipe" scheme
+		c.config.dialOptions = append(c.config.dialOptions, grpc.WithContextDialer(winio.DialPipeContext))
+	}
+
+	c.config.address, err = parseTargetFromStringAddr(c.config.address)
 	return err
 }
 

--- a/v2/workloadapi/client_windows_test.go
+++ b/v2/workloadapi/client_windows_test.go
@@ -18,7 +18,7 @@ func TestWithNamedPipeName(t *testing.T) {
 	wl := fakeworkloadapi.NewWithNamedPipeListener(t)
 	defer wl.Stop()
 
-	pipeName := getPipeName(wl.Addr())
+	pipeName := strings.TrimPrefix(wl.Addr(), "npipe:")
 	c, err := New(context.Background(), WithNamedPipeName(pipeName))
 	require.NoError(t, err)
 	defer c.Close()
@@ -46,8 +46,4 @@ func TestWithNamedPipeNameError(t *testing.T) {
 	_, err = c.FetchX509SVID(context.Background())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), `ohno: The system cannot find the file specified`)
-}
-
-func getPipeName(s string) string {
-	return strings.TrimPrefix(s, `\\.\pipe`)
 }


### PR DESCRIPTION
This PR adds support to Named Pipes in gRPC target strings.
The `npipe` URI scheme is now supported to specify a named pipe target address. An opaque URI is used for this:
- `npipe:<pipeName>`: where `pipeName` is the named pipe name in the local host.