### PR TITLE
Fix some spiffetls typos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .build/
+
+# Editor specific configuration
+.idea
+.vscode

--- a/v2/spiffetls/dial.go
+++ b/v2/spiffetls/dial.go
@@ -59,9 +59,9 @@ func DialWithMode(ctx context.Context, network, addr string, mode DialMode, opti
 	case tlsClientMode:
 		tlsconfig.HookTLSClientConfig(tlsConfig, m.bundle, m.authorizer)
 	case mtlsClientMode:
-		tlsconfig.HookMTLSClientConfig(tlsConfig, m.svid, m.bundle, m.authorizer, opt.tlsoptions...)
+		tlsconfig.HookMTLSClientConfig(tlsConfig, m.svid, m.bundle, m.authorizer, opt.tlsOptions...)
 	case mtlsWebClientMode:
-		tlsconfig.HookMTLSWebClientConfig(tlsConfig, m.svid, m.roots, opt.tlsoptions...)
+		tlsconfig.HookMTLSWebClientConfig(tlsConfig, m.svid, m.roots, opt.tlsOptions...)
 	default:
 		return nil, spiffetlsErr.New("unknown client mode: %v", m.mode)
 	}

--- a/v2/spiffetls/listen.go
+++ b/v2/spiffetls/listen.go
@@ -89,9 +89,9 @@ func NewListenerWithMode(ctx context.Context, inner net.Listener, mode ListenMod
 
 	switch m.mode {
 	case tlsServerMode:
-		tlsconfig.HookTLSServerConfig(tlsConfig, m.svid, opt.tlsoptions...)
+		tlsconfig.HookTLSServerConfig(tlsConfig, m.svid, opt.tlsOptions...)
 	case mtlsServerMode:
-		tlsconfig.HookMTLSServerConfig(tlsConfig, m.svid, m.bundle, m.authorizer, opt.tlsoptions...)
+		tlsconfig.HookMTLSServerConfig(tlsConfig, m.svid, m.bundle, m.authorizer, opt.tlsOptions...)
 	case mtlsWebServerMode:
 		tlsconfig.HookMTLSWebServerConfig(tlsConfig, m.cert, m.bundle, m.authorizer)
 	default:

--- a/v2/spiffetls/mode.go
+++ b/v2/spiffetls/mode.go
@@ -135,7 +135,7 @@ func MTLSClient(authorizer tlsconfig.Authorizer) DialMode {
 	}
 }
 
-// MTLSClientWithSource configures the dialing for mutally authenticated TLS
+// MTLSClientWithSource configures the dialing for mutually authenticated TLS
 // (mTLS). The client X509-SVID and the X.509 bundles used to authenticate the
 // server X509-SVID are obtained via the provided Workload API X.509 source.
 // The source must remain valid for the lifetime of the connection. The

--- a/v2/spiffetls/option.go
+++ b/v2/spiffetls/option.go
@@ -24,14 +24,14 @@ func (fn dialOption) apply(c *dialConfig) {
 type dialConfig struct {
 	baseTLSConf *tls.Config
 	dialer      *net.Dialer
-	tlsoptions  []tlsconfig.Option
+	tlsOptions  []tlsconfig.Option
 }
 
 type listenOption func(*listenConfig)
 
 type listenConfig struct {
 	baseTLSConf *tls.Config
-	tlsoptions  []tlsconfig.Option
+	tlsOptions  []tlsconfig.Option
 }
 
 func (fn listenOption) apply(c *listenConfig) {
@@ -50,7 +50,7 @@ func WithDialTLSConfigBase(base *tls.Config) DialOption {
 // WithDialTLSOptions provides options to use for the TLS config.
 func WithDialTLSOptions(opts ...tlsconfig.Option) DialOption {
 	return dialOption(func(c *dialConfig) {
-		c.tlsoptions = opts
+		c.tlsOptions = opts
 	})
 }
 
@@ -79,6 +79,6 @@ func WithListenTLSConfigBase(base *tls.Config) ListenOption {
 // WithListenTLSOptions provides options to use when doing Server mTLS.
 func WithListenTLSOptions(opts ...tlsconfig.Option) ListenOption {
 	return listenOption(func(c *listenConfig) {
-		c.tlsoptions = opts
+		c.tlsOptions = opts
 	})
 }

--- a/v2/spiffetls/tlsconfig/config.go
+++ b/v2/spiffetls/tlsconfig/config.go
@@ -18,7 +18,7 @@ func TLSClientConfig(bundle x509bundle.Source, authorizer Authorizer, opts ...Op
 
 // HookTLSClientConfig sets up the TLS configuration to verify and authorize
 // the server X509-SVID. If there is an existing callback set for
-// VerifyPeerCertificate it will be wrapped by by this package and invoked
+// VerifyPeerCertificate it will be wrapped by this package and invoked
 // after SPIFFE authentication has completed.
 func HookTLSClientConfig(config *tls.Config, bundle x509bundle.Source, authorizer Authorizer, opts ...Option) {
 	resetAuthFields(config)
@@ -65,7 +65,7 @@ func MTLSClientConfig(svid x509svid.Source, bundle x509bundle.Source, authorizer
 
 // HookMTLSClientConfig sets up the TLS configuration to present an X509-SVID
 // to the server and verify and authorize the server X509-SVID. If there is an
-// existing callback set for VerifyPeerCertificate it will be wrapped by by
+// existing callback set for VerifyPeerCertificate it will be wrapped by
 // this package and invoked after SPIFFE authentication has completed.
 func HookMTLSClientConfig(config *tls.Config, svid x509svid.Source, bundle x509bundle.Source, authorizer Authorizer, opts ...Option) {
 	resetAuthFields(config)
@@ -118,7 +118,7 @@ func MTLSServerConfig(svid x509svid.Source, bundle x509bundle.Source, authorizer
 // HookMTLSServerConfig sets up the TLS configuration to present an X509-SVID
 // to the client and require, verify, and authorize the client X509-SVID. If
 // there is an existing callback set for VerifyPeerCertificate it will be
-// wrapped by by this package and invoked after SPIFFE authentication has
+// wrapped by this package and invoked after SPIFFE authentication has
 // completed.
 func HookMTLSServerConfig(config *tls.Config, svid x509svid.Source, bundle x509bundle.Source, authorizer Authorizer, opts ...Option) {
 	resetAuthFields(config)
@@ -139,7 +139,7 @@ func MTLSWebServerConfig(cert *tls.Certificate, bundle x509bundle.Source, author
 // HookMTLSWebServerConfig sets up the TLS configuration to presents a web
 // server certificate to the client and require, verify, and authorize client
 // X509-SVIDs. If there is an existing callback set for VerifyPeerCertificate
-// it will be wrapped by by this package and invoked after SPIFFE
+// it will be wrapped by this package and invoked after SPIFFE
 // authentication has completed.
 func HookMTLSWebServerConfig(config *tls.Config, cert *tls.Certificate, bundle x509bundle.Source, authorizer Authorizer, opts ...Option) {
 	resetAuthFields(config)
@@ -181,7 +181,7 @@ func VerifyPeerCertificate(bundle x509bundle.Source, authorizer Authorizer, opts
 	}
 }
 
-// WrapVerifyPeerCertificate wraps a VeriyPeerCertificate callback, performing
+// WrapVerifyPeerCertificate wraps a VerifyPeerCertificate callback, performing
 // SPIFFE authentication against the peer certificates using the given bundle and
 // authorizer. The wrapped callback will be passed the verified chains.
 // Note: TLS clients must set `InsecureSkipVerify` when doing SPIFFE authentication to disable hostname verification.


### PR DESCRIPTION
Fix some typos from spiffetls packages, and add editor configs on gitignore