### PR TITLE
Fix corrupt certificate test

### DIFF
--- a/v2/svid/x509svid/svid_test.go
+++ b/v2/svid/x509svid/svid_test.go
@@ -129,7 +129,7 @@ func TestParse(t *testing.T) {
 			name:           "Corrupt certificate",
 			keyPath:        keyRSA,
 			certsPath:      corruptCert,
-			expErrContains: "x509svid: cannot parse PEM encoded certificate: asn1: structure error:",
+			expErrContains: "x509svid: cannot parse PEM encoded certificate: x509: malformed certificate",
 		},
 		{
 			name:           "Certificate does not match private key",


### PR DESCRIPTION
The error message returned by the `x509` package in the test case changed with a newer version of Go. Update the test to look for the new error message.