### PR TITLE
Export PeerIDFromConnectionState

### DIFF
--- a/v2/spiffetls/dial.go
+++ b/v2/spiffetls/dial.go
@@ -102,5 +102,5 @@ func (c *clientConn) Close() error {
 // been completed. Note that in Go's TLS stack, the TLS 1.3 handshake may not
 // complete until the first read from the connection.
 func (c *clientConn) PeerID() (spiffeid.ID, error) {
-	return peerIDFromConnectionState(c.Conn.ConnectionState())
+	return PeerIDFromConnectionState(c.Conn.ConnectionState())
 }

--- a/v2/spiffetls/listen.go
+++ b/v2/spiffetls/listen.go
@@ -146,5 +146,5 @@ type serverConn struct {
 // been completed. Note that in Go's TLS stack, the TLS 1.3 handshake may not
 // complete until the first read from the connection.
 func (c *serverConn) PeerID() (spiffeid.ID, error) {
-	return peerIDFromConnectionState(c.Conn.ConnectionState())
+	return PeerIDFromConnectionState(c.Conn.ConnectionState())
 }

--- a/v2/spiffetls/peerid.go
+++ b/v2/spiffetls/peerid.go
@@ -22,7 +22,7 @@ func PeerIDFromConn(conn net.Conn) (spiffeid.ID, error) {
 	return spiffeid.ID{}, spiffetlsErr.New("connection does not expose peer ID")
 }
 
-func peerIDFromConnectionState(state tls.ConnectionState) (spiffeid.ID, error) {
+func PeerIDFromConnectionState(state tls.ConnectionState) (spiffeid.ID, error) {
 	// The connection state unfortunately does not have VerifiedChains set
 	// because SPIFFE TLS does custom verification, i.e., Go's TLS stack only
 	// sets VerifiedChains if it is the one to verify the chain of trust. The


### PR DESCRIPTION
This was mentioned on Slack that it could useful to have to be able extract the SPIFFE ID from a [http.Request](https://pkg.go.dev/net/http#Request) strucutre.