### PR TITLE
Add a convenience Name method to the TrustDomain type

### DIFF
--- a/v2/spiffeid/trustdomain.go
+++ b/v2/spiffeid/trustdomain.go
@@ -50,7 +50,12 @@ func TrustDomainFromURI(uri *url.URL) (TrustDomain, error) {
 	return id.TrustDomain(), nil
 }
 
-// String returns the trust domain as a string, e.g. example.org.
+// Name returns the trust domain name as a string, e.g. example.org.
+func (td TrustDomain) Name() string {
+	return td.name
+}
+
+// String returns the trust domain name as a string, e.g. example.org.
 func (td TrustDomain) String() string {
 	return td.name
 }


### PR DESCRIPTION
Code that needs a string representing the trust domain name currently goes through the String() method:

```
var td spiffeid.TrustDomain = ...
var tdName = td.String()
```

However, the code reads more clearly if we introduce a Name method:

```
var td spiffeid.TrustDomain = ...
var tdName = td.Name()
```