### PR TITLE
Move svid access after error checking

### DIFF
--- a/v2/workloadapi/client.go
+++ b/v2/workloadapi/client.go
@@ -538,10 +538,10 @@ func parseJWTSVIDs(resp *workload.JWTSVIDResponse, audience []string, firstOnly 
 		hints[svid.Hint] = struct{}{}
 
 		s, err := jwtsvid.ParseInsecure(svid.Svid, audience)
-		s.Hint = svid.Hint
 		if err != nil {
 			return nil, err
 		}
+		s.Hint = svid.Hint
 		svids = append(svids, s)
 	}
 


### PR DESCRIPTION
If ParseInsecure fails it returns a nil svid so we should not use it before checking the error. Otherwise we get:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x58 pc=0x842b52]

goroutine 1 [running]:
github.com/spiffe/go-spiffe/v2/workloadapi.parseJWTSVIDs(0xc000292480, {0xc0002b4860, 0x2, 0x2}, 0x0?)
	go-spiffe/v2@v2.1.6/workloadapi/client.go:541 +0x252
github.com/spiffe/go-spiffe/v2/workloadapi.(*Client).FetchJWTSVID(0xc00012a600, {0x9f15d0?, 0xc00011c010?}, {{0x935b0a, 0x2}, {0xc000290920, 0x1, 0x1}, {{0x0, 0x0}, ...}})
	go-spiffe/v2@v2.1.6/workloadapi/client.go:181 +0x227
github.com/spiffe/go-spiffe/v2/workloadapi.(*JWTSource).FetchJWTSVID(0xc00012c410, {0x9f15d0, 0xc00011c010}, {{0x935b0a, 0x2}, {0xc000290920, 0x1, 0x1}, {{0x0, 0x0}, ...}})
	github.com/spiffe/go-spiffe/v2@v2.1.6/workloadapi/jwtsource.go:64 +0xa2
main.run({0x9f15d0, 0xc00011c010})
	jwt-fetch.go:46 +0x445
main.main()
	jwt-fetch.go:18 +0x27
exit status 2
```