### PR TITLE
Support Ed25519 signature algorithm

### DIFF
--- a/v2/internal/cryptoutil/keys.go
+++ b/v2/internal/cryptoutil/keys.go
@@ -1,8 +1,10 @@
 package cryptoutil
 
 import (
+	"bytes"
 	"crypto"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/rsa"
 	"fmt"
 )
@@ -15,6 +17,9 @@ func PublicKeyEqual(a, b crypto.PublicKey) (bool, error) {
 	case *ecdsa.PublicKey:
 		ecdsaPublicKey, ok := b.(*ecdsa.PublicKey)
 		return ok && ECDSAPublicKeyEqual(a, ecdsaPublicKey), nil
+	case ed25519.PublicKey:
+		ed25519PublicKey, ok := b.(ed25519.PublicKey)
+		return ok && bytes.Equal(a, ed25519PublicKey), nil
 	default:
 		return false, fmt.Errorf("unsupported public key type %T", a)
 	}

--- a/v2/svid/jwtsvid/svid_test.go
+++ b/v2/svid/jwtsvid/svid_test.go
@@ -3,6 +3,7 @@ package jwtsvid_test
 import (
 	"crypto"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
@@ -502,6 +503,8 @@ func getSignerAlgorithm(signer crypto.Signer) (jose.SignatureAlgorithm, error) {
 		default:
 			return "", fmt.Errorf("unable to determine signature algorithm for EC public key size %d", params.BitSize)
 		}
+	case ed25519.PublicKey:
+		return jose.EdDSA, nil
 	default:
 		return "", fmt.Errorf("unable to determine signature algorithm for public key type %T", publicKey)
 	}

--- a/v2/svid/x509svid/svid.go
+++ b/v2/svid/x509svid/svid.go
@@ -1,8 +1,10 @@
 package x509svid
 
 import (
+	"bytes"
 	"crypto"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/rsa"
 	"crypto/x509"
 	"os"
@@ -229,6 +231,9 @@ func keyMatches(privateKey crypto.PrivateKey, publicKey crypto.PublicKey) (bool,
 	case *ecdsa.PrivateKey:
 		ecdsaPublicKey, ok := publicKey.(*ecdsa.PublicKey)
 		return ok && ecdsaPublicKeyEqual(&privateKey.PublicKey, ecdsaPublicKey), nil
+	case ed25519.PrivateKey:
+		ed25519PublicKey, ok := publicKey.(ed25519.PublicKey)
+		return ok && bytes.Equal(privateKey.Public().(ed25519.PublicKey), ed25519PublicKey), nil
 	default:
 		return false, errs.New("unsupported private key type %T", privateKey)
 	}


### PR DESCRIPTION
This adds support for the Ed25519 signature algorithm which is supported by Go, but was not fully plumbed through in go-spiffe.