### PR TITLE
Fix race on watcher update check

### DIFF
--- a/v2/workloadapi/watcher.go
+++ b/v2/workloadapi/watcher.go
@@ -141,10 +141,10 @@ func (w *watcher) Close() error {
 
 func (w *watcher) OnX509ContextUpdate(x509Context *X509Context) {
 	w.x509ContextFn(x509Context)
+	w.triggerUpdated()
 	w.x509ContextSetOnce.Do(func() {
 		close(w.x509ContextSet)
 	})
-	w.triggerUpdated()
 }
 
 func (w *watcher) OnX509ContextWatchError(err error) {
@@ -154,10 +154,10 @@ func (w *watcher) OnX509ContextWatchError(err error) {
 
 func (w *watcher) OnJWTBundlesUpdate(jwtBundles *jwtbundle.Set) {
 	w.jwtBundlesFn(jwtBundles)
+	w.triggerUpdated()
 	w.jwtBundlesSetOnce.Do(func() {
 		close(w.jwtBundlesSet)
 	})
-	w.triggerUpdated()
 }
 
 func (w *watcher) OnJWTBundlesWatchError(error) {


### PR DESCRIPTION
When watchers are initialized, they wait until the Workload API has streamed back the initial response before returning from NewXXXWatcher. The semantics are intended such that a call to WaitForUpdate afterwards will only complete when the next response has arrived.

When an update is received, the flow is to:
1. record the update
2. close the "got first response" channel (only happens once)
3. send on the "updated" channel (to signal callers of WaitForUpdate)

However, this sequence is racy, since closing the "got first response" channel first unblocks the newWatcher call then drains the "updated" channel. If the drain happens after step (3) then everything is ok, but if it happens before, then step (3) will send on the channel, which is buffered. This causes the call to WaitForUpdate to unblock even though no update was received.

This change fixes the race by swapping steps (2) and (3). The "updated" channel is sent on and THEN the "got first response channel" is closed so that the drain can take place afterwards.