### PR TITLE
GHA: Build/Test matrix for linux/windows - Go1.19/1.20/1.21

### DIFF
--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -2,53 +2,32 @@ name: PR Build
 on:
   pull_request: {}
   workflow_dispatch: {}
-env:
-  GO_VERSION: 1.19
 jobs:
-  lint-linux:
-    runs-on: ubuntu-latest
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        RUNS_ON: [ubuntu-latest, windows-2022]
+        GO_VERSION: ["1.19.x", "1.20.x", "1.21.x"]
+    runs-on: "${{ matrix.RUNS_ON }}"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup go
+      - name: Setup go ${{ matrix.GO_VERSION }}
         uses: actions/setup-go@v5
         with:
           cache: true
           cache-dependency-path: v2/go.sum
-          go-version: ${{ env.GO_VERSION }}
-      - name: Lint
+          go-version: ${{ matrix.GO_VERSION }}
+      - name: Lint linux - ${{ matrix.GO_VERSION }}
+        if: ${{ contains(matrix.RUNS_ON, 'ubuntu') }}
         run: make lint
-
-  test-linux:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup go
-        uses: actions/setup-go@v5
-        with:
-          cache: true
-          cache-dependency-path: v2/go.sum
-          go-version: ${{ env.GO_VERSION }}
-      - name: Test
+      - name: Test linux - ${{ matrix.GO_VERSION }}
+        if: ${{ contains(matrix.RUNS_ON, 'ubuntu') }}
         run: make test
-
-  lint-windows:
-    runs-on: windows-2022
-    defaults:
-      run:
-        shell: msys2 {0}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup go
-        uses: actions/setup-go@v5
-        with:
-          cache: true
-          cache-dependency-path: v2/go.sum
-          go-version: ${{ env.GO_VERSION }}
       - name: Install msys2
         uses: msys2/setup-msys2@v2
+        if: ${{ contains(matrix.RUNS_ON, 'windows') }}
         with:
           msystem: MINGW64
           update: true
@@ -57,41 +36,20 @@ jobs:
             base-devel 
             mingw-w64-x86_64-toolchain 
             unzip 
-      - name: Lint
+      - name: Lint windows - Go ${{ matrix.GO_VERSION }}
+        if: ${{ contains(matrix.RUNS_ON, 'windows') }}
+        shell: msys2 {0}
         run: make lint
-
-  test-windows:
-    runs-on: windows-2022
-    defaults:
-      run:
+      - name: Test windows - Go ${{ matrix.GO_VERSION }}
+        if: ${{ contains(matrix.RUNS_ON, 'windows') }}
         shell: msys2 {0}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup go
-        uses: actions/setup-go@v5
-        with:
-          cache: true
-          cache-dependency-path: v2/go.sum
-          go-version: ${{ env.GO_VERSION }}
-      - name: Install msys2
-        uses: msys2/setup-msys2@v2
-        with:
-          msystem: MINGW64
-          update: true
-          install: >-
-            git
-            base-devel 
-            mingw-w64-x86_64-toolchain 
-            unzip 
-      - name: Test
         run: make test
 
   # This job is just here to make sure that the other jobs have completed
   # and is used as a single job to block PR merge from. GH doesn't have a
   # way to say "all jobs from this action", which would be ideal.
   success:
-    needs: [lint-linux, test-linux, lint-windows, test-windows]
+    needs: [build]
     runs-on: ubuntu-latest
     steps:
       - name: Shout it out


### PR DESCRIPTION
- fixes #206

However, unless the makefile is modified, only 1.19 is actually executed.
This is why pr is still a draft.