### PR TITLE
Fix Makefile for Apple Silicon-based Macs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,8 @@ ifeq ($(arch1),x86_64)
 arch2=amd64
 else ifeq ($(arch1),aarch64)
 arch2=arm64
+else ifeq ($(arch1),arm64)
+arch2=arm64
 else
 $(error unsupported ARCH: $(arch1))
 endif


### PR DESCRIPTION
Output of `uname -m` on my M2 Mac
```
arm64
```