### PR TITLE
Bump Go to 1.21

### DIFF
--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -3,7 +3,7 @@ on:
   pull_request: {}
   workflow_dispatch: {}
 env:
-  GO_VERSION: 1.19
+  GO_VERSION: 1.21
 jobs:
   lint-linux:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ protoc_gen_go_grpc_base_dir := $(build_dir)/protoc-gen-go-grpc
 protoc_gen_go_grpc_dir := $(protoc_gen_go_grpc_base_dir)/$(protoc_gen_go_grpc_version)-go$(go_version)
 protoc_gen_go_grpc_bin := $(protoc_gen_go_grpc_dir)/protoc-gen-go-grpc
 
-golangci_lint_version = v1.50.1
+golangci_lint_version = v1.57.2
 golangci_lint_dir = $(build_dir)/golangci_lint/$(golangci_lint_version)
 golangci_lint_bin = $(golangci_lint_dir)/golangci-lint
 

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ apiprotos := \
 # Toolchain
 #############################################################################
 
-go_version_full := 1.19.12
+go_version_full := 1.21.8
 go_version := $(go_version_full:.0=)
 go_dir := $(build_dir)/go/$(go_version)
 

--- a/v2/.golangci.yml
+++ b/v2/.golangci.yml
@@ -2,20 +2,9 @@ run:
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   deadline: 10m
 
-  # include examples
-  skip-dirs-use-default: false
-
-  skip-dirs:
-    - testdata$
-    - test/mock
-
-  skip-files:
-    - ".*\\.pb\\.go"
-
 linters:
   enable:
     - bodyclose
-    - depguard
     - goimports
     - revive
     - gosec
@@ -28,6 +17,16 @@ linters:
     - gocritic
 
 issues:
+  # include examples
+  exclude-dirs-use-default: false
+
+  exclude-dirs:
+    - testdata$
+    - test/mock
+
+  exclude-files:
+    - ".*\\.pb\\.go"
+
   exclude-rules:
     # exclude some lints from examples test files
     - path: examples_test.go
@@ -40,3 +39,7 @@ linters-settings:
   golint:
     # minimal confidence for issues, default is 0.8
     min-confidence: 0.0
+  revive:
+    rules:
+      - name: unused-parameter
+        disabled: true # It's useful to name parameters in library code for better readability

--- a/v2/internal/test/fakeworkloadapi/workload_api.go
+++ b/v2/internal/test/fakeworkloadapi/workload_api.go
@@ -50,7 +50,7 @@ func New(tb testing.TB) *WorkloadAPI {
 		x509BundlesChans: make(map[chan *workload.X509BundlesResponse]struct{}),
 	}
 
-	listener, err := newListener()
+	listener, err := newListener(tb)
 	require.NoError(tb, err)
 
 	server := grpc.NewServer()

--- a/v2/internal/test/fakeworkloadapi/workload_api_posix.go
+++ b/v2/internal/test/fakeworkloadapi/workload_api_posix.go
@@ -6,9 +6,10 @@ package fakeworkloadapi
 import (
 	"fmt"
 	"net"
+	"testing"
 )
 
-func newListener() (net.Listener, error) {
+func newListener(_ testing.TB) (net.Listener, error) {
 	return net.Listen("tcp", "localhost:0")
 }
 

--- a/v2/internal/test/fakeworkloadapi/workload_api_windows.go
+++ b/v2/internal/test/fakeworkloadapi/workload_api_windows.go
@@ -17,13 +17,15 @@ import (
 	"google.golang.org/grpc"
 )
 
+var rs = randSource()
+
 func NewWithNamedPipeListener(tb testing.TB) *WorkloadAPI {
 	w := &WorkloadAPI{
 		x509Chans:       make(map[chan *workload.X509SVIDResponse]struct{}),
 		jwtBundlesChans: make(map[chan *workload.JWTBundlesResponse]struct{}),
 	}
 
-	listener, err := winio.ListenPipe(fmt.Sprintf(`\\.\pipe\go-spiffe-test-pipe-%x`, rand.Uint64()), nil) //nolint: gosec // not use for crypto
+	listener, err := winio.ListenPipe(fmt.Sprintf(`\\.\pipe\go-spiffe-test-pipe-%x`, rs.Uint64()), nil) //nolint: gosec // not use for crypto
 	require.NoError(tb, err)
 
 	server := grpc.NewServer()
@@ -45,12 +47,12 @@ func GetPipeName(s string) string {
 	return strings.TrimPrefix(s, `\\.\pipe`)
 }
 
-func init() {
-	rand.Seed(time.Now().UnixNano())
+func randSource() *rand.Rand {
+	return rand.New(rand.NewSource(time.Now().UnixNano()))
 }
 
 func newListener() (net.Listener, error) {
-	return winio.ListenPipe(fmt.Sprintf(`\\.\pipe\go-spiffe-test-pipe-%x`, rand.Uint64()), nil) //nolint: gosec // not used for crypto
+	return winio.ListenPipe(fmt.Sprintf(`\\.\pipe\go-spiffe-test-pipe-%x`, rs.Uint64()), nil) //nolint: gosec // not used for crypto
 }
 
 func getTargetName(addr net.Addr) string {

--- a/v2/internal/test/fakeworkloadapi/workload_api_windows.go
+++ b/v2/internal/test/fakeworkloadapi/workload_api_windows.go
@@ -23,7 +23,7 @@ func NewWithNamedPipeListener(tb testing.TB) *WorkloadAPI {
 		jwtBundlesChans: make(map[chan *workload.JWTBundlesResponse]struct{}),
 	}
 
-	listener, err := winio.ListenPipe(fmt.Sprintf(`\\.\pipe\go-spiffe-test-pipe-%x`, randUint64()), nil)
+	listener, err := winio.ListenPipe(fmt.Sprintf(`\\.\pipe\go-spiffe-test-pipe-%x`, randUint64(tb)), nil)
 	require.NoError(tb, err)
 
 	server := grpc.NewServer()
@@ -54,8 +54,8 @@ func randUint64(t testing.TB) uint64 {
 	return n.Uint64()
 }
 
-func newListener() (net.Listener, error) {
-	return winio.ListenPipe(fmt.Sprintf(`\\.\pipe\go-spiffe-test-pipe-%x`, randUint64()), nil)
+func newListener(tb testing.TB) (net.Listener, error) {
+	return winio.ListenPipe(fmt.Sprintf(`\\.\pipe\go-spiffe-test-pipe-%x`, randUint64(tb)), nil)
 }
 
 func getTargetName(addr net.Addr) string {

--- a/v2/internal/test/fakeworkloadapi/workload_api_windows.go
+++ b/v2/internal/test/fakeworkloadapi/workload_api_windows.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"math"
+	"math/big"
 	"net"
 	"strings"
 	"testing"
@@ -16,6 +17,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
+
+var maxUint64 = maxBigUint64()
 
 func NewWithNamedPipeListener(tb testing.TB) *WorkloadAPI {
 	w := &WorkloadAPI{
@@ -45,8 +48,13 @@ func GetPipeName(s string) string {
 	return strings.TrimPrefix(s, `\\.\pipe`)
 }
 
+func maxBigUint64() *big.Int {
+	n := big.NewInt(0)
+	return n.SetUint64(math.MaxUint64)
+}
+
 func randUint64(t testing.TB) uint64 {
-	n, err := rand.Int(rand.Reader, math.MaxUint32)
+	n, err := rand.Int(rand.Reader, maxUint64)
 	if err != nil {
 		t.Fail()
 	}


### PR DESCRIPTION
The latest version of `github.com/go-jose/go-jose` depends on Go 1.21+. Since Go 1.21 has been released since March 2023, it should be safer to use it for building/testing code in the repo.

Also bump `golangci-lint` to latest version 1.57.2, as the older version used in the repo is incompatible with Go 1.21+. Some additional changes to make the lint build pass:

- Exclude `depcheck` linter that was previously enabled, but not configured. It now causes the lint build to fail since no dependencies are configured in the allowlist.
- Disable `unused-parameter` rule in `revive` linter, since naming parameters can be helpful for documentation purposes in libraries.
- Reorganize `golangci-lint` config that was moved in newer versions.
- Fix usage of rand source in Windows `fakeworkloadapi` that was depending on a deprecated `rand.Seed()` method as well as a weak random number generator from `math/rand`.