### PR TITLE
Allow empty x509 bundles to be sent in responses

### DIFF
--- a/v2/bundle/x509bundle/bundle.go
+++ b/v2/bundle/x509bundle/bundle.go
@@ -63,12 +63,13 @@ func Read(trustDomain spiffeid.TrustDomain, r io.Reader) (*Bundle, error) {
 // blocks.
 func Parse(trustDomain spiffeid.TrustDomain, b []byte) (*Bundle, error) {
 	bundle := New(trustDomain)
+	if len(b) == 0 {
+		return bundle, nil
+	}
+
 	certs, err := pemutil.ParseCertificates(b)
 	if err != nil {
 		return nil, x509bundleErr.New("cannot parse certificate: %v", err)
-	}
-	if len(certs) == 0 {
-		return nil, x509bundleErr.New("no certificates found")
 	}
 	for _, cert := range certs {
 		bundle.AddX509Authority(cert)
@@ -80,12 +81,13 @@ func Parse(trustDomain spiffeid.TrustDomain, b []byte) (*Bundle, error) {
 // with no intermediate padding if there are more than one certificate)
 func ParseRaw(trustDomain spiffeid.TrustDomain, b []byte) (*Bundle, error) {
 	bundle := New(trustDomain)
+	if len(b) == 0 {
+		return bundle, nil
+	}
+
 	certs, err := x509.ParseCertificates(b)
 	if err != nil {
 		return nil, x509bundleErr.New("cannot parse certificate: %v", err)
-	}
-	if len(certs) == 0 {
-		return nil, x509bundleErr.New("no certificates found")
 	}
 	for _, cert := range certs {
 		bundle.AddX509Authority(cert)

--- a/v2/bundle/x509bundle/bundle_test.go
+++ b/v2/bundle/x509bundle/bundle_test.go
@@ -96,19 +96,14 @@ func TestParse(t *testing.T) {
 			expNumAuthorities: 1,
 		},
 		{
-			name:           "Parse empty bytes should fail",
-			path:           "testdata/empty.pem",
-			expErrContains: "x509bundle: cannot parse certificate: no PEM blocks found",
+			name:              "Parse empty bytes should result in empty bundle",
+			path:              "testdata/empty.pem",
+			expNumAuthorities: 0,
 		},
 		{
 			name:           "Parse non-PEM bytes should fail",
 			path:           "testdata/not-pem.pem",
 			expErrContains: "x509bundle: cannot parse certificate: no PEM blocks found",
-		},
-		{
-			name:           "Parse should fail if no certificate block is is found",
-			path:           "testdata/key.pem",
-			expErrContains: "x509bundle: no certificates found",
 		},
 		{
 			name:           "Parse a corrupted certificate should fail",
@@ -155,9 +150,9 @@ func TestParseRaw(t *testing.T) {
 			expNumAuthorities: 1,
 		},
 		{
-			name:           "Parse should fail if no certificate block is is found",
-			path:           "testdata/key.pem",
-			expErrContains: "x509bundle: no certificates found",
+			name:              "Parse should not fail if no certificate block is is found",
+			path:              "testdata/empty.pem",
+			expNumAuthorities: 0,
 		},
 	}
 
@@ -321,6 +316,10 @@ func TestClone(t *testing.T) {
 func loadRawCertificates(t *testing.T, path string) []byte {
 	certsBytes, err := os.ReadFile(path)
 	require.NoError(t, err)
+
+	if len(certsBytes) == 0 {
+		return []byte{}
+	}
 
 	certs, err := pemutil.ParseCertificates(certsBytes)
 	require.NoError(t, err)

--- a/v2/bundle/x509bundle/bundle_test.go
+++ b/v2/bundle/x509bundle/bundle_test.go
@@ -318,7 +318,7 @@ func loadRawCertificates(t *testing.T, path string) []byte {
 	require.NoError(t, err)
 
 	if len(certsBytes) == 0 {
-		return []byte{}
+		return nil
 	}
 
 	certs, err := pemutil.ParseCertificates(certsBytes)

--- a/v2/workloadapi/client.go
+++ b/v2/workloadapi/client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/x509"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/spiffe/go-spiffe/v2/bundle/jwtbundle"
@@ -488,9 +487,6 @@ func parseX509Bundle(spiffeID string, bundle []byte) (*x509bundle.Bundle, error)
 	certs, err := x509.ParseCertificates(bundle)
 	if err != nil {
 		return nil, err
-	}
-	if len(certs) == 0 {
-		return nil, fmt.Errorf("empty X.509 bundle for trust domain %q", td)
 	}
 	return x509bundle.FromX509Authorities(td, certs), nil
 }

--- a/v2/workloadapi/client_test.go
+++ b/v2/workloadapi/client_test.go
@@ -190,7 +190,7 @@ func TestFetchX509Context(t *testing.T) {
 	assertX509Bundle(t, x509Ctx.Bundles, td, ca.X509Bundle())
 	assertX509Bundle(t, x509Ctx.Bundles, federatedTD, federatedCA.X509Bundle())
 
-	// Now set the next response with an empty federated bundles and assert that the call
+	// Now set the next response with an empty federated bundle and assert that the call
 	// still succeeds.
 	wl.SetX509SVIDResponse(&fakeworkloadapi.X509SVIDResponse{
 		Bundle:           ca.X509Bundle(),

--- a/v2/workloadapi/client_test.go
+++ b/v2/workloadapi/client_test.go
@@ -190,16 +190,22 @@ func TestFetchX509Context(t *testing.T) {
 	assertX509Bundle(t, x509Ctx.Bundles, td, ca.X509Bundle())
 	assertX509Bundle(t, x509Ctx.Bundles, federatedTD, federatedCA.X509Bundle())
 
-	// Now set the next response without any bundles and assert that the call
-	// fails since the bundle cannot be empty.
+	// Now set the next response with an empty federated bundles and assert that the call
+	// still succeeds.
 	wl.SetX509SVIDResponse(&fakeworkloadapi.X509SVIDResponse{
-		SVIDs: svids,
+		Bundle:           ca.X509Bundle(),
+		SVIDs:            svids,
+		FederatedBundles: []*x509bundle.Bundle{x509bundle.FromX509Authorities(federatedCA.Bundle().TrustDomain(), nil)},
 	})
 
 	x509Ctx, err = c.FetchX509Context(context.Background())
-
-	require.EqualError(t, err, `empty X.509 bundle for trust domain "example.org"`)
-	require.Nil(t, x509Ctx)
+	require.NoError(t, err)
+	// inspect svids
+	require.Len(t, x509Ctx.SVIDs, 4)
+	assertX509SVID(t, x509Ctx.SVIDs[0], fooID, resp.SVIDs[0].Certificates, hintInternal)
+	assertX509SVID(t, x509Ctx.SVIDs[1], barID, resp.SVIDs[1].Certificates, hintExternal)
+	assertX509SVID(t, x509Ctx.SVIDs[2], emptyHintSVID1.ID, resp.SVIDs[3].Certificates, "")
+	assertX509SVID(t, x509Ctx.SVIDs[3], emptyHintSVID2.ID, resp.SVIDs[4].Certificates, "")
 }
 
 func TestWatchX509Context(t *testing.T) {


### PR DESCRIPTION
Otherwise federating with a trust domain that publishes an empty trust bundle at some point will cause your workloads to stop being able to fetch SVIDs. The only result of that should be the inability to verify SVIDs from the federated trust domain.

The [specifications](https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Trust_Domain_and_Bundle.md/#413-keys) already allows this to happen.