### PR TITLE
tlsconfig: Add support for configuring use of PQ KEMs during TLS handshake

### DIFF
--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -1,12 +1,17 @@
 name: PR Build
 on:
+  push: {}
   pull_request: {}
   workflow_dispatch: {}
+env:
+  GOTOOLCHAIN: local
 jobs:
   lint-linux:
     strategy:
       matrix:
-        GO_VERSION: ["1.21", "1.23rc2"]
+        go-version:
+          - setup: "1.21"
+            makeArgs: ""
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -16,14 +21,18 @@ jobs:
         with:
           cache: true
           cache-dependency-path: v2/go.sum
-          go-version: ${{ matrix.GO_VERSION }}
+          go-version: ${{ matrix.go-version.setup }}
       - name: Lint
-        run: make lint
+        run: make lint ${{ matrix.go-version.makeArgs }}
 
   test-linux:
     strategy:
       matrix:
-        GO_VERSION: ["1.21", "1.23rc2"]
+        go-version:
+          - setup: "1.21"
+            makeArgs: ""
+          - setup: "1.23.0-rc.2"
+            makeArgs: "go_version_full=1.23rc2"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -33,14 +42,16 @@ jobs:
         with:
           cache: true
           cache-dependency-path: v2/go.sum
-          go-version: ${{ matrix.GO_VERSION }}
+          go-version: ${{ matrix.go-version.setup }}
       - name: Test
-        run: make test
+        run: make test ${{ matrix.go-version.makeArgs }}
 
   lint-windows:
     strategy:
       matrix:
-        GO_VERSION: ["1.21", "1.23rc2"]
+        go-version:
+          - setup: "1.21"
+            makeArgs: ""
     runs-on: windows-2022
     defaults:
       run:
@@ -53,7 +64,7 @@ jobs:
         with:
           cache: true
           cache-dependency-path: v2/go.sum
-          go-version: ${{ matrix.GO_VERSION }}
+          go-version: ${{ matrix.go-version.setup }}
       - name: Install msys2
         uses: msys2/setup-msys2@v2
         with:
@@ -65,12 +76,16 @@ jobs:
             mingw-w64-x86_64-toolchain 
             unzip 
       - name: Lint
-        run: make lint
+        run: make lint ${{ matrix.go-version.makeArgs }}
 
   test-windows:
     strategy:
       matrix:
-        GO_VERSION: ["1.21", "1.23rc2"]
+        go-version:
+          - setup: "1.21"
+            makeArgs: ""
+          - setup: "1.23.0-rc.2"
+            makeArgs: "go_version_full=1.23rc2"
     runs-on: windows-2022
     defaults:
       run:
@@ -83,7 +98,7 @@ jobs:
         with:
           cache: true
           cache-dependency-path: v2/go.sum
-          go-version: ${{ matrix.GO_VERSION }}
+          go-version: ${{ matrix.go-version.setup }}
       - name: Install msys2
         uses: msys2/setup-msys2@v2
         with:
@@ -95,7 +110,7 @@ jobs:
             mingw-w64-x86_64-toolchain 
             unzip 
       - name: Test
-        run: make test
+        run: make test ${{ matrix.go-version.makeArgs }}
 
   # This job is just here to make sure that the other jobs have completed
   # and is used as a single job to block PR merge from. GH doesn't have a

--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -2,10 +2,11 @@ name: PR Build
 on:
   pull_request: {}
   workflow_dispatch: {}
-env:
-  GO_VERSION: 1.21
 jobs:
   lint-linux:
+    strategy:
+      matrix:
+        GO_VERSION: ["1.21", "1.23rc2"]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -15,11 +16,14 @@ jobs:
         with:
           cache: true
           cache-dependency-path: v2/go.sum
-          go-version: ${{ env.GO_VERSION }}
+          go-version: ${{ matrix.GO_VERSION }}
       - name: Lint
         run: make lint
 
   test-linux:
+    strategy:
+      matrix:
+        GO_VERSION: ["1.21", "1.23rc2"]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -29,11 +33,14 @@ jobs:
         with:
           cache: true
           cache-dependency-path: v2/go.sum
-          go-version: ${{ env.GO_VERSION }}
+          go-version: ${{ matrix.GO_VERSION }}
       - name: Test
         run: make test
 
   lint-windows:
+    strategy:
+      matrix:
+        GO_VERSION: ["1.21", "1.23rc2"]
     runs-on: windows-2022
     defaults:
       run:
@@ -46,7 +53,7 @@ jobs:
         with:
           cache: true
           cache-dependency-path: v2/go.sum
-          go-version: ${{ env.GO_VERSION }}
+          go-version: ${{ matrix.GO_VERSION }}
       - name: Install msys2
         uses: msys2/setup-msys2@v2
         with:
@@ -61,6 +68,9 @@ jobs:
         run: make lint
 
   test-windows:
+    strategy:
+      matrix:
+        GO_VERSION: ["1.21", "1.23rc2"]
     runs-on: windows-2022
     defaults:
       run:
@@ -73,7 +83,7 @@ jobs:
         with:
           cache: true
           cache-dependency-path: v2/go.sum
-          go-version: ${{ env.GO_VERSION }}
+          go-version: ${{ matrix.GO_VERSION }}
       - name: Install msys2
         uses: msys2/setup-msys2@v2
         with:

--- a/v2/spiffetls/tlsconfig/config_test.go
+++ b/v2/spiffetls/tlsconfig/config_test.go
@@ -44,6 +44,11 @@ func TestTLSClientConfig(t *testing.T) {
 	assert.Nil(t, config.NameToCertificate) //nolint:staticcheck // setting to nil is OK
 	assert.Nil(t, config.RootCAs)
 	assert.NotNil(t, config.VerifyPeerCertificate)
+	assert.Nil(t, config.CurvePreferences)
+
+	config = tlsconfig.TLSClientConfig(bundle, tlsconfig.AuthorizeAny(),
+		tlsconfig.WithPQKEMMode(tlsconfig.PQKEMModeRequire))
+	assert.Greater(t, len(config.CurvePreferences), 0)
 }
 
 func TestHookTLSClientConfig(t *testing.T) {
@@ -62,7 +67,15 @@ func TestHookTLSClientConfig(t *testing.T) {
 	assert.Nil(t, config.NameToCertificate) //nolint:staticcheck // setting to nil is OK
 	assert.Nil(t, config.RootCAs)
 	assert.NotNil(t, config.VerifyPeerCertificate)
+	assert.Equal(t, []tls.CurveID{tls.CurveP256}, config.CurvePreferences)
 	assertUnrelatedFieldsUntouched(t, base, config)
+
+	base = createBaseTLSConfig()
+	config = createTestTLSConfig(base)
+
+	tlsconfig.HookTLSClientConfig(config, bundle, tlsconfig.AuthorizeAny(),
+		tlsconfig.WithPQKEMMode(tlsconfig.PQKEMModeAttempt))
+	assert.Greater(t, len(config.CurvePreferences), 0)
 }
 
 func TestMTLSClientConfig(t *testing.T) {
@@ -82,6 +95,12 @@ func TestMTLSClientConfig(t *testing.T) {
 	assert.Nil(t, config.NameToCertificate) //nolint:staticcheck // setting to nil is OK
 	assert.Nil(t, config.RootCAs)
 	assert.NotNil(t, config.VerifyPeerCertificate)
+	assert.Nil(t, config.CurvePreferences)
+
+	config = tlsconfig.MTLSClientConfig(svid, bundle, tlsconfig.AuthorizeAny(),
+		tlsconfig.WithTrace(localTrace),
+		tlsconfig.WithPQKEMMode(tlsconfig.PQKEMModeAttempt))
+	assert.Greater(t, len(config.CurvePreferences), 0)
 }
 
 func TestHookMTLSClientConfig(t *testing.T) {
@@ -103,7 +122,16 @@ func TestHookMTLSClientConfig(t *testing.T) {
 	assert.Nil(t, config.NameToCertificate) //nolint:staticcheck // setting to nil is OK
 	assert.Nil(t, config.RootCAs)
 	assert.NotNil(t, config.VerifyPeerCertificate)
+	assert.Equal(t, []tls.CurveID{tls.CurveP256}, config.CurvePreferences)
 	assertUnrelatedFieldsUntouched(t, base, config)
+
+	base = createBaseTLSConfig()
+	config = createTestTLSConfig(base)
+
+	tlsconfig.HookMTLSClientConfig(config, svid, bundle, tlsconfig.AuthorizeAny(),
+		tlsconfig.WithTrace(localTrace),
+		tlsconfig.WithPQKEMMode(tlsconfig.PQKEMModeAttempt))
+	assert.Greater(t, len(config.CurvePreferences), 0)
 }
 
 func TestMTLSWebClientConfig(t *testing.T) {
@@ -122,6 +150,12 @@ func TestMTLSWebClientConfig(t *testing.T) {
 	assert.Nil(t, config.NameToCertificate) //nolint:staticcheck // setting to nil is OK
 	assert.Equal(t, roots, config.RootCAs)
 	assert.Nil(t, config.VerifyPeerCertificate)
+	assert.Nil(t, config.CurvePreferences)
+
+	config = tlsconfig.MTLSWebClientConfig(svid, roots,
+		tlsconfig.WithTrace(localTrace),
+		tlsconfig.WithPQKEMMode(tlsconfig.PQKEMModeAttempt))
+	assert.Greater(t, len(config.CurvePreferences), 0)
 }
 
 func TestHookMTLSWebClientConfig(t *testing.T) {
@@ -143,7 +177,17 @@ func TestHookMTLSWebClientConfig(t *testing.T) {
 	assert.Nil(t, config.NameToCertificate) //nolint:staticcheck // setting to nil is OK
 	assert.Equal(t, roots, config.RootCAs)
 	assert.Nil(t, config.VerifyPeerCertificate)
+	assert.Equal(t, []tls.CurveID{tls.CurveP256}, config.CurvePreferences)
 	assertUnrelatedFieldsUntouched(t, base, config)
+
+	base = createBaseTLSConfig()
+	config = createTestTLSConfig(base)
+	tlsconfig.HookMTLSWebClientConfig(config, svid, roots,
+		tlsconfig.WithTrace(localTrace),
+		tlsconfig.WithPQKEMMode(tlsconfig.PQKEMModeAttempt),
+	)
+
+	assert.Greater(t, len(config.CurvePreferences), 0)
 }
 
 func TestTLSServerConfig(t *testing.T) {
@@ -161,6 +205,13 @@ func TestTLSServerConfig(t *testing.T) {
 	assert.Nil(t, config.NameToCertificate) //nolint:staticcheck // setting to nil is OK
 	assert.Nil(t, config.RootCAs)
 	assert.Nil(t, config.VerifyPeerCertificate)
+	assert.Nil(t, config.CurvePreferences)
+
+	config = tlsconfig.TLSServerConfig(svid,
+		tlsconfig.WithTrace(localTrace),
+		tlsconfig.WithPQKEMMode(tlsconfig.PQKEMModeRequire),
+	)
+	assert.Greater(t, len(config.CurvePreferences), 0)
 }
 
 func TestHookTLSServerConfig(t *testing.T) {
@@ -181,6 +232,16 @@ func TestHookTLSServerConfig(t *testing.T) {
 	assert.Nil(t, config.RootCAs)
 	assert.Nil(t, config.VerifyPeerCertificate)
 	assertUnrelatedFieldsUntouched(t, base, config)
+	assert.Equal(t, []tls.CurveID{tls.CurveP256}, config.CurvePreferences)
+
+	base = createBaseTLSConfig()
+	config = createTestTLSConfig(base)
+
+	tlsconfig.HookTLSServerConfig(config, svid,
+		tlsconfig.WithTrace(localTrace),
+		tlsconfig.WithPQKEMMode(tlsconfig.PQKEMModeAttempt),
+	)
+	assert.Greater(t, len(config.CurvePreferences), 0)
 }
 
 func TestMTLSServerConfig(t *testing.T) {
@@ -200,6 +261,13 @@ func TestMTLSServerConfig(t *testing.T) {
 	assert.Nil(t, config.NameToCertificate) //nolint:staticcheck // setting to nil is OK
 	assert.Nil(t, config.RootCAs)
 	assert.NotNil(t, config.VerifyPeerCertificate)
+	assert.Nil(t, config.CurvePreferences)
+
+	config = tlsconfig.MTLSServerConfig(svid, bundle, tlsconfig.AuthorizeAny(),
+		tlsconfig.WithTrace(localTrace),
+		tlsconfig.WithPQKEMMode(tlsconfig.PQKEMModeRequire),
+	)
+	assert.Greater(t, len(config.CurvePreferences), 0)
 }
 
 func TestHookMTLSServerConfig(t *testing.T) {
@@ -221,7 +289,17 @@ func TestHookMTLSServerConfig(t *testing.T) {
 	assert.Nil(t, config.NameToCertificate) //nolint:staticcheck // setting to nil is OK
 	assert.Nil(t, config.RootCAs)
 	assert.NotNil(t, config.VerifyPeerCertificate)
+	assert.Equal(t, []tls.CurveID{tls.CurveP256}, config.CurvePreferences)
 	assertUnrelatedFieldsUntouched(t, base, config)
+
+	base = createBaseTLSConfig()
+	config = createTestTLSConfig(base)
+
+	tlsconfig.HookMTLSServerConfig(config, svid, bundle, tlsconfig.AuthorizeAny(),
+		tlsconfig.WithTrace(localTrace),
+		tlsconfig.WithPQKEMMode(tlsconfig.PQKEMModeRequire),
+	)
+	assert.Greater(t, len(config.CurvePreferences), 0)
 }
 
 func TestMTLSWebServerConfig(t *testing.T) {
@@ -239,6 +317,11 @@ func TestMTLSWebServerConfig(t *testing.T) {
 	assert.Nil(t, config.NameToCertificate) //nolint:staticcheck // setting to nil is OK
 	assert.Nil(t, config.RootCAs)
 	assert.NotNil(t, config.VerifyPeerCertificate)
+	assert.Nil(t, config.CurvePreferences)
+
+	config = tlsconfig.MTLSWebServerConfig(tlsCert, bundle, tlsconfig.AuthorizeAny(),
+		tlsconfig.WithPQKEMMode(tlsconfig.PQKEMModeRequire))
+	assert.Greater(t, len(config.CurvePreferences), 0)
 }
 
 func TestHookMTLSWebServerConfig(t *testing.T) {
@@ -258,7 +341,15 @@ func TestHookMTLSWebServerConfig(t *testing.T) {
 	assert.Nil(t, config.NameToCertificate) //nolint:staticcheck // setting to nil is OK
 	assert.Nil(t, config.RootCAs)
 	assert.NotNil(t, config.VerifyPeerCertificate)
+	assert.Equal(t, []tls.CurveID{tls.CurveP256}, config.CurvePreferences)
 	assertUnrelatedFieldsUntouched(t, base, config)
+
+	base = createBaseTLSConfig()
+	config = createTestTLSConfig(base)
+
+	tlsconfig.HookMTLSWebServerConfig(config, tlsCert, bundle, tlsconfig.AuthorizeAny(),
+		tlsconfig.WithPQKEMMode(tlsconfig.PQKEMModeRequire))
+	assert.Greater(t, len(config.CurvePreferences), 0)
 }
 
 func hookedTracer(onGetCertificate, onGotCertificate func()) tlsconfig.Trace {
@@ -516,6 +607,10 @@ func TestWrapVerifyPeerCertificate(t *testing.T) {
 	}
 }
 
+func isPQKEMSupported(t *testing.T) bool {
+	return supportsPQKEM
+}
+
 func TestTLSHandshake(t *testing.T) {
 	td := spiffeid.RequireTrustDomainFromString("domain1.test")
 	ca1 := test.NewCA(t, td)
@@ -532,16 +627,41 @@ func TestTLSHandshake(t *testing.T) {
 	bundle3 := ca3.Bundle()
 
 	testCases := []struct {
-		name         string
-		serverConfig *tls.Config
-		clientConfig *tls.Config
-		clientErr    string
-		serverErr    string
+		name          string
+		serverConfig  *tls.Config
+		clientConfig  *tls.Config
+		clientErr     string
+		serverErr     string
+		shouldRunFunc func(t *testing.T) bool
 	}{
 		{
 			name:         "success",
 			serverConfig: tlsconfig.TLSServerConfig(serverSVID),
 			clientConfig: tlsconfig.TLSClientConfig(bundle1, tlsconfig.AuthorizeAny()),
+		},
+		{
+			name:          "success (PQ KEM attempted)",
+			serverConfig:  tlsconfig.TLSServerConfig(serverSVID, tlsconfig.WithPQKEMMode(tlsconfig.PQKEMModeAttempt)),
+			clientConfig:  tlsconfig.TLSClientConfig(bundle1, tlsconfig.AuthorizeAny(), tlsconfig.WithPQKEMMode(tlsconfig.PQKEMModeAttempt)),
+			shouldRunFunc: isPQKEMSupported,
+		},
+		{
+			name:          "success (PQ KEM required by client)",
+			serverConfig:  tlsconfig.TLSServerConfig(serverSVID, tlsconfig.WithPQKEMMode(tlsconfig.PQKEMModeAttempt)),
+			clientConfig:  tlsconfig.TLSClientConfig(bundle1, tlsconfig.AuthorizeAny(), tlsconfig.WithPQKEMMode(tlsconfig.PQKEMModeRequire)),
+			shouldRunFunc: isPQKEMSupported,
+		},
+		{
+			name:          "success (PQ KEM required by server)",
+			serverConfig:  tlsconfig.TLSServerConfig(serverSVID, tlsconfig.WithPQKEMMode(tlsconfig.PQKEMModeRequire)),
+			clientConfig:  tlsconfig.TLSClientConfig(bundle1, tlsconfig.AuthorizeAny(), tlsconfig.WithPQKEMMode(tlsconfig.PQKEMModeAttempt)),
+			shouldRunFunc: isPQKEMSupported,
+		},
+		{
+			name:          "success (PQ KEM mutually required)",
+			serverConfig:  tlsconfig.TLSServerConfig(serverSVID, tlsconfig.WithPQKEMMode(tlsconfig.PQKEMModeRequire)),
+			clientConfig:  tlsconfig.TLSClientConfig(bundle1, tlsconfig.AuthorizeAny(), tlsconfig.WithPQKEMMode(tlsconfig.PQKEMModeRequire)),
+			shouldRunFunc: isPQKEMSupported,
 		},
 		{
 			name:         "authentication fails",
@@ -569,7 +689,9 @@ func TestTLSHandshake(t *testing.T) {
 	for _, testCase := range testCases {
 		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
-			testConnection(t, testCase.serverConfig, testCase.clientConfig, testCase.serverErr, testCase.clientErr)
+			if testCase.shouldRunFunc == nil || testCase.shouldRunFunc(t) {
+				testConnection(t, testCase.serverConfig, testCase.clientConfig, testCase.serverErr, testCase.clientErr)
+			}
 		})
 	}
 }

--- a/v2/spiffetls/tlsconfig/examples_test.go
+++ b/v2/spiffetls/tlsconfig/examples_test.go
@@ -26,7 +26,9 @@ func ExampleMTLSServerConfig_fileSource() {
 		// TODO: handle error
 	}
 
-	config := tlsconfig.MTLSServerConfig(svid, bundle, tlsconfig.AuthorizeMemberOf(td))
+	config := tlsconfig.MTLSServerConfig(svid, bundle, tlsconfig.AuthorizeMemberOf(td),
+		tlsconfig.WithPQKEMMode(tlsconfig.PQKEMModeAttempt))
+
 	// TODO: use the config
 	config = config
 }
@@ -43,7 +45,8 @@ func ExampleMTLSServerConfig_workloadAPISource() {
 	}
 	defer source.Close()
 
-	config := tlsconfig.MTLSServerConfig(source, source, tlsconfig.AuthorizeMemberOf(td))
+	config := tlsconfig.MTLSServerConfig(source, source, tlsconfig.AuthorizeMemberOf(td),
+		tlsconfig.WithPQKEMMode(tlsconfig.PQKEMModeRequire))
 	// TODO: use the config
 	config = config
 }

--- a/v2/spiffetls/tlsconfig/pqkem_no_test.go
+++ b/v2/spiffetls/tlsconfig/pqkem_no_test.go
@@ -1,0 +1,5 @@
+//go:build !go1.23
+
+package tlsconfig_test
+
+const supportsPQKEM = false

--- a/v2/spiffetls/tlsconfig/pqkem_yes_test.go
+++ b/v2/spiffetls/tlsconfig/pqkem_yes_test.go
@@ -1,0 +1,5 @@
+//go:build go1.23
+
+package tlsconfig_test
+
+const supportsPQKEM = true


### PR DESCRIPTION
This adds a new option to `spiffetls/tlsconfig` which enables the opportunistic or mandatory use of a post-quantum-safe TLS KEM to be configured. This leverages the addition of the X25519Kyber768Draft00 TLS KEM to Go 1.23 and depends on that support in order to be useful.

This is useful for SPIFFE Workload API clients, though the intention is also to use this in SPIRE as it is cleaner than simply performing process-global manipulation of GODEBUG.