### PR TITLE
Remove github.com/zeebo/errs

### DIFF
--- a/v2/bundle/jwtbundle/set.go
+++ b/v2/bundle/jwtbundle/set.go
@@ -1,6 +1,7 @@
 package jwtbundle
 
 import (
+	"fmt"
 	"sort"
 	"sync"
 
@@ -98,7 +99,7 @@ func (s *Set) GetJWTBundleForTrustDomain(trustDomain spiffeid.TrustDomain) (*Bun
 
 	bundle, ok := s.bundles[trustDomain]
 	if !ok {
-		return nil, jwtbundleErr.New("no JWT bundle for trust domain %q", trustDomain)
+		return nil, wrapJwtbundleErr(fmt.Errorf("no JWT bundle for trust domain %q", trustDomain))
 	}
 
 	return bundle, nil

--- a/v2/bundle/spiffebundle/set.go
+++ b/v2/bundle/spiffebundle/set.go
@@ -1,6 +1,7 @@
 package spiffebundle
 
 import (
+	"fmt"
 	"sort"
 	"sync"
 
@@ -100,7 +101,7 @@ func (s *Set) GetBundleForTrustDomain(trustDomain spiffeid.TrustDomain) (*Bundle
 
 	bundle, ok := s.bundles[trustDomain]
 	if !ok {
-		return nil, spiffebundleErr.New("no SPIFFE bundle for trust domain %q", trustDomain)
+		return nil, wrapSpiffebundleErr(fmt.Errorf("no SPIFFE bundle for trust domain %q", trustDomain))
 	}
 
 	return bundle, nil
@@ -114,7 +115,7 @@ func (s *Set) GetX509BundleForTrustDomain(trustDomain spiffeid.TrustDomain) (*x5
 
 	bundle, ok := s.bundles[trustDomain]
 	if !ok {
-		return nil, spiffebundleErr.New("no X.509 bundle for trust domain %q", trustDomain)
+		return nil, wrapSpiffebundleErr(fmt.Errorf("no X.509 bundle for trust domain %q", trustDomain))
 	}
 
 	return bundle.X509Bundle(), nil
@@ -128,7 +129,7 @@ func (s *Set) GetJWTBundleForTrustDomain(trustDomain spiffeid.TrustDomain) (*jwt
 
 	bundle, ok := s.bundles[trustDomain]
 	if !ok {
-		return nil, spiffebundleErr.New("no JWT bundle for trust domain %q", trustDomain)
+		return nil, wrapSpiffebundleErr(fmt.Errorf("no JWT bundle for trust domain %q", trustDomain))
 	}
 
 	return bundle.JWTBundle(), nil

--- a/v2/bundle/x509bundle/bundle.go
+++ b/v2/bundle/x509bundle/bundle.go
@@ -2,6 +2,7 @@ package x509bundle
 
 import (
 	"crypto/x509"
+	"fmt"
 	"io"
 	"os"
 	"sync"
@@ -9,10 +10,7 @@ import (
 	"github.com/spiffe/go-spiffe/v2/internal/pemutil"
 	"github.com/spiffe/go-spiffe/v2/internal/x509util"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
-	"github.com/zeebo/errs"
 )
-
-var x509bundleErr = errs.Class("x509bundle")
 
 // Bundle is a collection of trusted X.509 authorities for a trust domain.
 type Bundle struct {
@@ -42,7 +40,7 @@ func FromX509Authorities(trustDomain spiffeid.TrustDomain, authorities []*x509.C
 func Load(trustDomain spiffeid.TrustDomain, path string) (*Bundle, error) {
 	fileBytes, err := os.ReadFile(path)
 	if err != nil {
-		return nil, x509bundleErr.New("unable to load X.509 bundle file: %w", err)
+		return nil, wrapX509bundleErr(fmt.Errorf("unable to load X.509 bundle file: %w", err))
 	}
 
 	return Parse(trustDomain, fileBytes)
@@ -53,7 +51,7 @@ func Load(trustDomain spiffeid.TrustDomain, path string) (*Bundle, error) {
 func Read(trustDomain spiffeid.TrustDomain, r io.Reader) (*Bundle, error) {
 	b, err := io.ReadAll(r)
 	if err != nil {
-		return nil, x509bundleErr.New("unable to read X.509 bundle: %v", err)
+		return nil, wrapX509bundleErr(fmt.Errorf("unable to read X.509 bundle: %v", err))
 	}
 
 	return Parse(trustDomain, b)
@@ -69,7 +67,7 @@ func Parse(trustDomain spiffeid.TrustDomain, b []byte) (*Bundle, error) {
 
 	certs, err := pemutil.ParseCertificates(b)
 	if err != nil {
-		return nil, x509bundleErr.New("cannot parse certificate: %v", err)
+		return nil, wrapX509bundleErr(fmt.Errorf("cannot parse certificate: %v", err))
 	}
 	for _, cert := range certs {
 		bundle.AddX509Authority(cert)
@@ -87,7 +85,7 @@ func ParseRaw(trustDomain spiffeid.TrustDomain, b []byte) (*Bundle, error) {
 
 	certs, err := x509.ParseCertificates(b)
 	if err != nil {
-		return nil, x509bundleErr.New("cannot parse certificate: %v", err)
+		return nil, wrapX509bundleErr(fmt.Errorf("cannot parse certificate: %v", err))
 	}
 	for _, cert := range certs {
 		bundle.AddX509Authority(cert)
@@ -195,8 +193,12 @@ func (b *Bundle) Clone() *Bundle {
 // returned if the trust domain does not match that of the bundle.
 func (b *Bundle) GetX509BundleForTrustDomain(trustDomain spiffeid.TrustDomain) (*Bundle, error) {
 	if b.trustDomain != trustDomain {
-		return nil, x509bundleErr.New("no X.509 bundle found for trust domain: %q", trustDomain)
+		return nil, wrapX509bundleErr(fmt.Errorf("no X.509 bundle found for trust domain: %q", trustDomain))
 	}
 
 	return b, nil
+}
+
+func wrapX509bundleErr(err error) error {
+	return fmt.Errorf("x509bundle: %w", err)
 }

--- a/v2/bundle/x509bundle/set.go
+++ b/v2/bundle/x509bundle/set.go
@@ -1,6 +1,7 @@
 package x509bundle
 
 import (
+	"fmt"
 	"sort"
 	"sync"
 
@@ -98,7 +99,7 @@ func (s *Set) GetX509BundleForTrustDomain(trustDomain spiffeid.TrustDomain) (*Bu
 
 	bundle, ok := s.bundles[trustDomain]
 	if !ok {
-		return nil, x509bundleErr.New("no X.509 bundle for trust domain %q", trustDomain)
+		return nil, wrapX509bundleErr(fmt.Errorf("no X.509 bundle for trust domain %q", trustDomain))
 	}
 
 	return bundle, nil

--- a/v2/federation/watch.go
+++ b/v2/federation/watch.go
@@ -2,6 +2,7 @@ package federation
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/spiffe/go-spiffe/v2/bundle/spiffebundle"
@@ -36,7 +37,7 @@ type BundleWatcher interface {
 // context is canceled, returning ctx.Err().
 func WatchBundle(ctx context.Context, trustDomain spiffeid.TrustDomain, url string, watcher BundleWatcher, options ...FetchOption) error {
 	if watcher == nil {
-		return federationErr.New("watcher cannot be nil")
+		return wrapFederationErr(errors.New("watcher cannot be nil"))
 	}
 
 	latestBundle := &spiffebundle.Bundle{}

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/Microsoft/go-winio v0.6.2
 	github.com/go-jose/go-jose/v4 v4.0.4
 	github.com/stretchr/testify v1.10.0
-	github.com/zeebo/errs v1.4.0
 	google.golang.org/grpc v1.70.0
 	google.golang.org/grpc/examples v0.0.0-20230224211313-3775f633ce20
 	google.golang.org/protobuf v1.36.1

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -23,8 +23,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/zeebo/errs v1.4.0 h1:XNdoD/RRMKP7HD0UhJnIzUy74ISdGGxURlYG8HSWSfM=
-github.com/zeebo/errs v1.4.0/go.mod h1:sgbWHsvVuTPHcqJJGQ1WhI5KbWlHYz+2+2C/LSEtCw4=
 go.opentelemetry.io/otel v1.32.0 h1:WnBN+Xjcteh0zdk01SVqV55d/m62NJLJdIyb4y/WO5U=
 go.opentelemetry.io/otel v1.32.0/go.mod h1:00DCVSB0RQcnzlwyTfqtxSm+DRr9hpYrHjNGiBHVQIg=
 go.opentelemetry.io/otel/metric v1.32.0 h1:xV2umtmNcThh2/a/aCP+h64Xx5wsj8qqnkYZktzNa0M=

--- a/v2/spiffetls/listen.go
+++ b/v2/spiffetls/listen.go
@@ -3,6 +3,7 @@ package spiffetls
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"io"
 	"net"
 
@@ -63,7 +64,7 @@ func NewListenerWithMode(ctx context.Context, inner net.Listener, mode ListenMod
 		if source == nil {
 			source, err = workloadapi.NewX509Source(ctx, m.options...)
 			if err != nil {
-				return nil, spiffetlsErr.New("cannot create X.509 source: %w", err)
+				return nil, wrapSpiffetlsErr(fmt.Errorf("cannot create X.509 source: %w", err))
 			}
 			// Close source if there is a failure after this point
 			defer func() {
@@ -95,7 +96,7 @@ func NewListenerWithMode(ctx context.Context, inner net.Listener, mode ListenMod
 	case mtlsWebServerMode:
 		tlsconfig.HookMTLSWebServerConfig(tlsConfig, m.cert, m.bundle, m.authorizer)
 	default:
-		return nil, spiffetlsErr.New("unknown server mode: %v", m.mode)
+		return nil, wrapSpiffetlsErr(fmt.Errorf("unknown server mode: %v", m.mode))
 	}
 
 	return &listener{
@@ -118,7 +119,7 @@ func (l *listener) Accept() (net.Conn, error) {
 	if !ok {
 		// This is purely defensive. The TLS listeners return tls.Conn's by contract.
 		conn.Close()
-		return nil, spiffetlsErr.New("unexpected conn type %T returned by TLS listener", conn)
+		return nil, wrapSpiffetlsErr(fmt.Errorf("unexpected conn type %T returned by TLS listener", conn))
 	}
 	return &serverConn{Conn: tlsConn}, nil
 }
@@ -133,7 +134,7 @@ func (l *listener) Close() error {
 		group.Add(l.sourceCloser.Close())
 	}
 	if err := l.inner.Close(); err != nil {
-		group.Add(spiffetlsErr.New("unable to close TLS connection: %w", err))
+		group.Add(wrapSpiffetlsErr(fmt.Errorf("unable to close TLS connection: %w", err)))
 	}
 	return group.Err()
 }

--- a/v2/spiffetls/option.go
+++ b/v2/spiffetls/option.go
@@ -2,13 +2,11 @@ package spiffetls
 
 import (
 	"crypto/tls"
+	"fmt"
 	"net"
 
 	"github.com/spiffe/go-spiffe/v2/spiffetls/tlsconfig"
-	"github.com/zeebo/errs"
 )
-
-var spiffetlsErr = errs.Class("spiffetls")
 
 // DialOption is an option for dialing. Option's are also DialOption's.
 type DialOption interface {
@@ -81,4 +79,8 @@ func WithListenTLSOptions(opts ...tlsconfig.Option) ListenOption {
 	return listenOption(func(c *listenConfig) {
 		c.tlsOptions = opts
 	})
+}
+
+func wrapSpiffetlsErr(err error) error {
+	return fmt.Errorf("spiffetls: %w", err)
 }

--- a/v2/svid/jwtsvid/svid.go
+++ b/v2/svid/jwtsvid/svid.go
@@ -1,13 +1,14 @@
 package jwtsvid
 
 import (
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/spiffe/go-spiffe/v2/bundle/jwtbundle"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
-	"github.com/zeebo/errs"
 )
 
 var (
@@ -22,8 +23,6 @@ var (
 		jose.PS384,
 		jose.PS512,
 	}
-
-	jwtsvidErr = errs.Class("jwtsvid")
 )
 
 // tokenValidator validates the token and returns the claims
@@ -54,25 +53,25 @@ func ParseAndValidate(token string, bundles jwtbundle.Source, audience []string)
 		// Obtain the key ID from the header
 		keyID := tok.Headers[0].KeyID
 		if keyID == "" {
-			return nil, jwtsvidErr.New("token header missing key id")
+			return nil, wrapJwtsvidErr(errors.New("token header missing key id"))
 		}
 
 		// Get JWT Bundle
 		bundle, err := bundles.GetJWTBundleForTrustDomain(trustDomain)
 		if err != nil {
-			return nil, jwtsvidErr.New("no bundle found for trust domain %q", trustDomain)
+			return nil, wrapJwtsvidErr(fmt.Errorf("no bundle found for trust domain %q", trustDomain))
 		}
 
 		// Find JWT authority using the key ID from the token header
 		authority, ok := bundle.FindJWTAuthority(keyID)
 		if !ok {
-			return nil, jwtsvidErr.New("no JWT authority %q found for trust domain %q", keyID, trustDomain)
+			return nil, wrapJwtsvidErr(fmt.Errorf("no JWT authority %q found for trust domain %q", keyID, trustDomain))
 		}
 
 		// Obtain and verify the token claims using the obtained JWT authority
 		claimsMap := make(map[string]interface{})
 		if err := tok.Claims(authority, &claimsMap); err != nil {
-			return nil, jwtsvidErr.New("unable to get claims from token: %v", err)
+			return nil, wrapJwtsvidErr(fmt.Errorf("unable to get claims from token: %v", err))
 		}
 
 		return claimsMap, nil
@@ -86,7 +85,7 @@ func ParseInsecure(token string, audience []string) (*SVID, error) {
 		// Obtain the token claims insecurely, i.e. without signature verification
 		claimsMap := make(map[string]interface{})
 		if err := tok.UnsafeClaimsWithoutVerification(&claimsMap); err != nil {
-			return nil, jwtsvidErr.New("unable to get claims from token: %v", err)
+			return nil, wrapJwtsvidErr(fmt.Errorf("unable to get claims from token: %v", err))
 		}
 
 		return claimsMap, nil
@@ -103,26 +102,26 @@ func parse(token string, audience []string, getClaims tokenValidator) (*SVID, er
 	// Parse serialized token
 	tok, err := jwt.ParseSigned(token, allowedSignatureAlgorithms)
 	if err != nil {
-		return nil, jwtsvidErr.New("unable to parse JWT token")
+		return nil, wrapJwtsvidErr(errors.New("unable to parse JWT token"))
 	}
 
 	// Parse out the unverified claims. We need to look up the key by the trust
 	// domain of the SPIFFE ID.
 	var claims jwt.Claims
 	if err := tok.UnsafeClaimsWithoutVerification(&claims); err != nil {
-		return nil, jwtsvidErr.New("unable to get claims from token: %v", err)
+		return nil, wrapJwtsvidErr(fmt.Errorf("unable to get claims from token: %v", err))
 	}
 
 	switch {
 	case claims.Subject == "":
-		return nil, jwtsvidErr.New("token missing subject claim")
+		return nil, wrapJwtsvidErr(errors.New("token missing subject claim"))
 	case claims.Expiry == nil:
-		return nil, jwtsvidErr.New("token missing exp claim")
+		return nil, wrapJwtsvidErr(errors.New("token missing exp claim"))
 	}
 
 	spiffeID, err := spiffeid.FromString(claims.Subject)
 	if err != nil {
-		return nil, jwtsvidErr.New("token has an invalid subject claim: %v", err)
+		return nil, wrapJwtsvidErr(fmt.Errorf("token has an invalid subject claim: %v", err))
 	}
 
 	// Create generic map of claims
@@ -139,9 +138,9 @@ func parse(token string, audience []string, getClaims tokenValidator) (*SVID, er
 		// Convert expected validation errors for pretty errors
 		switch err {
 		case jwt.ErrExpired:
-			err = jwtsvidErr.New("token has expired")
+			err = wrapJwtsvidErr(errors.New("token has expired"))
 		case jwt.ErrInvalidAudience:
-			err = jwtsvidErr.New("expected audience in %q (audience=%q)", audience, claims.Audience)
+			err = wrapJwtsvidErr(fmt.Errorf("expected audience in %q (audience=%q)", audience, claims.Audience))
 		}
 		return nil, err
 	}
@@ -153,4 +152,8 @@ func parse(token string, audience []string, getClaims tokenValidator) (*SVID, er
 		Claims:   claimsMap,
 		token:    token,
 	}, nil
+}
+
+func wrapJwtsvidErr(err error) error {
+	return fmt.Errorf("jwtsvid: %w", err)
 }

--- a/v2/svid/x509svid/verify.go
+++ b/v2/svid/x509svid/verify.go
@@ -2,15 +2,14 @@ package x509svid
 
 import (
 	"crypto/x509"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
 	"github.com/spiffe/go-spiffe/v2/internal/x509util"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
-	"github.com/zeebo/errs"
 )
-
-var x509svidErr = errs.Class("x509svid")
 
 // VerifyOption is an option used when verifying X509-SVIDs.
 type VerifyOption interface {
@@ -36,29 +35,29 @@ func Verify(certs []*x509.Certificate, bundleSource x509bundle.Source, opts ...V
 
 	switch {
 	case len(certs) == 0:
-		return spiffeid.ID{}, nil, x509svidErr.New("empty certificates chain")
+		return spiffeid.ID{}, nil, wrapX509svidErr(errors.New("empty certificates chain"))
 	case bundleSource == nil:
-		return spiffeid.ID{}, nil, x509svidErr.New("bundleSource is required")
+		return spiffeid.ID{}, nil, wrapX509svidErr(errors.New("bundleSource is required"))
 	}
 
 	leaf := certs[0]
 	id, err := IDFromCert(leaf)
 	if err != nil {
-		return spiffeid.ID{}, nil, x509svidErr.New("could not get leaf SPIFFE ID: %w", err)
+		return spiffeid.ID{}, nil, wrapX509svidErr(fmt.Errorf("could not get leaf SPIFFE ID: %w", err))
 	}
 
 	switch {
 	case leaf.IsCA:
-		return id, nil, x509svidErr.New("leaf certificate with CA flag set to true")
+		return id, nil, wrapX509svidErr(errors.New("leaf certificate with CA flag set to true"))
 	case leaf.KeyUsage&x509.KeyUsageCertSign > 0:
-		return id, nil, x509svidErr.New("leaf certificate with KeyCertSign key usage")
+		return id, nil, wrapX509svidErr(errors.New("leaf certificate with KeyCertSign key usage"))
 	case leaf.KeyUsage&x509.KeyUsageCRLSign > 0:
-		return id, nil, x509svidErr.New("leaf certificate with KeyCrlSign key usage")
+		return id, nil, wrapX509svidErr(errors.New("leaf certificate with KeyCrlSign key usage"))
 	}
 
 	bundle, err := bundleSource.GetX509BundleForTrustDomain(id.TrustDomain())
 	if err != nil {
-		return id, nil, x509svidErr.New("could not get X509 bundle: %w", err)
+		return id, nil, wrapX509svidErr(fmt.Errorf("could not get X509 bundle: %w", err))
 	}
 
 	verifiedChains, err := leaf.Verify(x509.VerifyOptions{
@@ -68,7 +67,7 @@ func Verify(certs []*x509.Certificate, bundleSource x509bundle.Source, opts ...V
 		CurrentTime:   config.now,
 	})
 	if err != nil {
-		return id, nil, x509svidErr.New("could not verify leaf certificate: %w", err)
+		return id, nil, wrapX509svidErr(fmt.Errorf("could not verify leaf certificate: %w", err))
 	}
 
 	return id, verifiedChains, nil
@@ -82,7 +81,7 @@ func ParseAndVerify(rawCerts [][]byte, bundleSource x509bundle.Source, opts ...V
 	for _, rawCert := range rawCerts {
 		cert, err := x509.ParseCertificate(rawCert)
 		if err != nil {
-			return spiffeid.ID{}, nil, x509svidErr.New("unable to parse certificate: %w", err)
+			return spiffeid.ID{}, nil, wrapX509svidErr(fmt.Errorf("unable to parse certificate: %w", err))
 		}
 		certs = append(certs, cert)
 	}
@@ -95,9 +94,9 @@ func ParseAndVerify(rawCerts [][]byte, bundleSource x509bundle.Source, opts ...V
 func IDFromCert(cert *x509.Certificate) (spiffeid.ID, error) {
 	switch {
 	case len(cert.URIs) == 0:
-		return spiffeid.ID{}, errs.New("certificate contains no URI SAN")
+		return spiffeid.ID{}, errors.New("certificate contains no URI SAN")
 	case len(cert.URIs) > 1:
-		return spiffeid.ID{}, errs.New("certificate contains more than one URI SAN")
+		return spiffeid.ID{}, errors.New("certificate contains more than one URI SAN")
 	}
 	return spiffeid.FromURI(cert.URIs[0])
 }
@@ -110,4 +109,8 @@ type verifyOption func(config *verifyConfig)
 
 func (fn verifyOption) apply(config *verifyConfig) {
 	fn(config)
+}
+
+func wrapX509svidErr(err error) error {
+	return fmt.Errorf("x509svid: %w", err)
 }

--- a/v2/workloadapi/jwtsource.go
+++ b/v2/workloadapi/jwtsource.go
@@ -2,15 +2,14 @@ package workloadapi
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"sync"
 
 	"github.com/spiffe/go-spiffe/v2/bundle/jwtbundle"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/go-spiffe/v2/svid/jwtsvid"
-	"github.com/zeebo/errs"
 )
-
-var jwtsourceErr = errs.Class("jwtsource")
 
 // JWTSource is a source of JWT-SVID and JWT bundles maintained via the
 // Workload API.
@@ -121,7 +120,11 @@ func (s *JWTSource) checkClosed() error {
 	s.closeMtx.RLock()
 	defer s.closeMtx.RUnlock()
 	if s.closed {
-		return jwtsourceErr.New("source is closed")
+		return wrapJwtsourceErr(errors.New("source is closed"))
 	}
 	return nil
+}
+
+func wrapJwtsourceErr(err error) error {
+	return fmt.Errorf("jwtsource: %w", err)
 }

--- a/v2/workloadapi/watcher.go
+++ b/v2/workloadapi/watcher.go
@@ -2,11 +2,11 @@ package workloadapi
 
 import (
 	"context"
+	"errors"
 	"sync"
 
 	"github.com/spiffe/go-spiffe/v2/bundle/jwtbundle"
 	"github.com/spiffe/go-spiffe/v2/svid/jwtsvid"
-	"github.com/zeebo/errs"
 )
 
 type sourceClient interface {
@@ -58,7 +58,7 @@ func newWatcher(ctx context.Context, config watcherConfig, x509ContextFn func(*X
 	// If this function fails, we need to clean up the source.
 	defer func() {
 		if err != nil {
-			err = errs.Combine(err, w.Close())
+			err = errors.Join(err, w.Close())
 		}
 	}()
 


### PR DESCRIPTION
Since go 1.20, [errors.Join](https://pkg.go.dev/errors@go1.20#Join) Added.

This unnecessary dependency can be removed.