### PR TITLE
Prepare to use GH merge queue

### DIFF
--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -1,0 +1,17 @@
+name: DCO
+on:
+  pull_request:
+  merge_group:
+jobs:
+  check_dco:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    name: Check DCO
+    steps:
+      - name: Run dco-check
+        uses: christophebedard/dco-check@7b0205d25ead0f898e0b706b58227dd5fa7e3f55 # 0.5.0
+        with:
+          args: --exclude-pattern 'dependabot\[bot\]@users\.noreply\.github\.com'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -1,7 +1,8 @@
 name: PR Build
 on:
-  pull_request: {}
-  workflow_dispatch: {}
+  pull_request:
+  merge_group:
+  workflow_dispatch:
 jobs:
   lint-linux:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- adds merge_group dispatch on the PR build workflow
- adds the dco-check workflow (to replace DCOBot, which doesn't work with merge queues)