### PR TITLE
Fix invalid examples link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,4 @@ streamed from the Workload API (e.g. secret rotation).
 
 ## Examples
 
-The [examples](./v2/examples) directory contains rich examples for a variety of circumstances.
+The [examples](./examples) directory contains rich examples for a variety of circumstances.


### PR DESCRIPTION
The link to examples directory in README.md was forgotten to be updated in PR #337