### PR TITLE
Make it possible to mock the current time in spiffetls dialer

### DIFF
--- a/spiffetls/dial.go
+++ b/spiffetls/dial.go
@@ -58,7 +58,7 @@ func DialWithMode(ctx context.Context, network, addr string, mode DialMode, opti
 
 	switch m.mode {
 	case tlsClientMode:
-		tlsconfig.HookTLSClientConfig(tlsConfig, m.bundle, m.authorizer)
+		tlsconfig.HookTLSClientConfig(tlsConfig, m.bundle, m.authorizer, opt.tlsOptions...)
 	case mtlsClientMode:
 		tlsconfig.HookMTLSClientConfig(tlsConfig, m.svid, m.bundle, m.authorizer, opt.tlsOptions...)
 	case mtlsWebClientMode:


### PR DESCRIPTION
So you can do, say,

  spiffetls.DialWithMode(
      ctx, network, addr, mode,
      spiffetls.WithDialTLSOptions(tlsconfig.WithTime(mocked))
  )

This is useful in tests and is already supported by the underlying crypto/x509 library and even by the x509svid package right here but just wasn't plumbed through to the dialer.