### PR TITLE
chore: bump minimum Go version to 1.25.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Minimum Go version is now go1.25.8, following our support policy.
+
 ## [2.6.0] - 2025-08-21
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ apiprotos := \
 # Toolchain
 #############################################################################
 
-go_version_full := 1.24.6
+go_version_full := 1.25.8
 go_version := $(go_version_full:.0=)
 go_dir := $(build_dir)/go/$(go_version)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/spiffe/go-spiffe/v2
 
-go 1.24.0
+go 1.25.8
 
 require (
 	github.com/Microsoft/go-winio v0.6.2


### PR DESCRIPTION
## What
- Update `go.mod` to require Go 1.25.8.
- Add an Unreleased changelog entry for the Go version bump.

## Why
- Align the repository's minimum supported Go version with its stated support policy.
