### PR TITLE
Fix current build break

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ protoc_gen_go_grpc_base_dir := $(build_dir)/protoc-gen-go-grpc
 protoc_gen_go_grpc_dir := $(protoc_gen_go_grpc_base_dir)/$(protoc_gen_go_grpc_version)-go$(go_version)
 protoc_gen_go_grpc_bin := $(protoc_gen_go_grpc_dir)/protoc-gen-go-grpc
 
-golangci_lint_version = v2.0.2
+golangci_lint_version = v2.11.4
 golangci_lint_dir = $(build_dir)/golangci_lint/$(golangci_lint_version)
 golangci_lint_bin = $(golangci_lint_dir)/golangci-lint
 
@@ -85,17 +85,17 @@ apiprotos := \
 # Toolchain
 #############################################################################
 
-go_version_full := 1.24.6
+go_version_full := 1.24.13
 go_version := $(go_version_full:.0=)
 go_dir := $(build_dir)/go/$(go_version)
 
 ifeq ($(os1),windows)
 	go_bin_dir = $(go_dir)/go/bin
-	go_url = https://storage.googleapis.com/golang/go$(go_version).$(os1)-$(arch2).zip
+	go_url = https://go.dev/dl/go$(go_version).$(os1)-$(arch2).zip
 	exe=".exe"
 else
 	go_bin_dir = $(go_dir)/bin
-	go_url = https://storage.googleapis.com/golang/go$(go_version).$(os1)-$(arch2).tar.gz
+	go_url = https://go.dev/dl/go$(go_version).$(os1)-$(arch2).tar.gz
 	exe=
 endif
 

--- a/examples/spiffe-jwt-using-proxy/proxy/main.go
+++ b/examples/spiffe-jwt-using-proxy/proxy/main.go
@@ -72,7 +72,7 @@ func run(ctx context.Context) error {
 
 func handler(p *httputil.ReverseProxy) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		log.Printf("%s %s", r.Method, r.URL)
+		log.Printf("%s %s", r.Method, r.URL) //nolint:gosec // G706: example code; log sanitization out of scope
 		p.ServeHTTP(w, r)
 	}
 }

--- a/spiffetls/spiffetls_test.go
+++ b/spiffetls/spiffetls_test.go
@@ -496,6 +496,11 @@ func setupTestEnv(t *testing.T) (*testEnv, func()) {
 
 	// Create custom workload API sources for the server
 	wlCtx, wlCancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer func() {
+		if testEnv.err != nil {
+			wlCancel()
+		}
+	}()
 	testEnv.wlCancel = wlCancel
 	testEnv.wlAPIClientA, testEnv.err = workloadapi.New(wlCtx, workloadapi.WithAddr(testEnv.wlAPIServerA.Addr()))
 	if testEnv.err != nil {

--- a/spiffetls/tlsconfig/config.go
+++ b/spiffetls/tlsconfig/config.go
@@ -23,7 +23,7 @@ func TLSClientConfig(bundle x509bundle.Source, authorizer Authorizer, opts ...Op
 func HookTLSClientConfig(config *tls.Config, bundle x509bundle.Source, authorizer Authorizer, opts ...Option) {
 	resetAuthFields(config)
 	config.InsecureSkipVerify = true
-	config.VerifyPeerCertificate = WrapVerifyPeerCertificate(config.VerifyPeerCertificate, bundle, authorizer, opts...)
+	config.VerifyPeerCertificate = WrapVerifyPeerCertificate(config.VerifyPeerCertificate, bundle, authorizer, opts...) //nolint:gosec // G123: VerifyConnection migration handled in a follow-up
 }
 
 // A Option changes the defaults used to by mTLS ClientConfig functions.
@@ -71,7 +71,7 @@ func HookMTLSClientConfig(config *tls.Config, svid x509svid.Source, bundle x509b
 	resetAuthFields(config)
 	config.GetClientCertificate = GetClientCertificate(svid, opts...)
 	config.InsecureSkipVerify = true
-	config.VerifyPeerCertificate = WrapVerifyPeerCertificate(config.VerifyPeerCertificate, bundle, authorizer, opts...)
+	config.VerifyPeerCertificate = WrapVerifyPeerCertificate(config.VerifyPeerCertificate, bundle, authorizer, opts...) //nolint:gosec // G123: VerifyConnection migration handled in a follow-up
 }
 
 // MTLSWebClientConfig returns a TLS configuration which presents an X509-SVID
@@ -124,7 +124,7 @@ func HookMTLSServerConfig(config *tls.Config, svid x509svid.Source, bundle x509b
 	resetAuthFields(config)
 	config.ClientAuth = tls.RequireAnyClientCert
 	config.GetCertificate = GetCertificate(svid, opts...)
-	config.VerifyPeerCertificate = WrapVerifyPeerCertificate(config.VerifyPeerCertificate, bundle, authorizer, opts...)
+	config.VerifyPeerCertificate = WrapVerifyPeerCertificate(config.VerifyPeerCertificate, bundle, authorizer, opts...) //nolint:gosec // G123: VerifyConnection migration handled in a follow-up
 }
 
 // MTLSWebServerConfig returns a TLS configuration which presents a web
@@ -145,7 +145,7 @@ func HookMTLSWebServerConfig(config *tls.Config, cert *tls.Certificate, bundle x
 	resetAuthFields(config)
 	config.ClientAuth = tls.RequireAnyClientCert
 	config.Certificates = []tls.Certificate{*cert}
-	config.VerifyPeerCertificate = WrapVerifyPeerCertificate(config.VerifyPeerCertificate, bundle, authorizer, opts...)
+	config.VerifyPeerCertificate = WrapVerifyPeerCertificate(config.VerifyPeerCertificate, bundle, authorizer, opts...) //nolint:gosec // G123: VerifyConnection migration handled in a follow-up
 }
 
 // GetCertificate returns a GetCertificate callback for tls.Config. It uses the

--- a/workloadapi/addr_posix_test.go
+++ b/workloadapi/addr_posix_test.go
@@ -21,7 +21,7 @@ func validateAddressCasesOS() []validateAddressCase {
 			addr: "unix://foo#whatever",
 			err:  "workload endpoint unix socket URI must not include a fragment",
 		},
-		{
+		{ //nolint:gosec // G101: intentional userinfo fixture exercising the rejection path
 			addr: "unix://john:doe@foo/path",
 			err:  "workload endpoint unix socket URI must not include user info",
 		},

--- a/workloadapi/addr_test.go
+++ b/workloadapi/addr_test.go
@@ -57,7 +57,7 @@ func TestValidateAddress(t *testing.T) {
 			addr: "tcp://1.2.3.4:5#whatever",
 			err:  "workload endpoint tcp socket URI must not include a fragment",
 		},
-		{
+		{ //nolint:gosec // G101: intentional userinfo fixture exercising the rejection path
 			addr: "tcp://john:doe@1.2.3.4:5/path",
 			err:  "workload endpoint tcp socket URI must not include user info",
 		},


### PR DESCRIPTION
Updates the linter and Go download URLs and versions. Stays with go1.24 for now just to unblock CI.