### PR TITLE
Add missing witbundle APIs for parity with jwtbundle

### DIFF
--- a/exp/bundle/witbundle/bundle.go
+++ b/exp/bundle/witbundle/bundle.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"os"
 	"sync"
 
 	"github.com/go-jose/go-jose/v4"
@@ -37,6 +39,28 @@ func FromWITAuthorities(trustDomain spiffeid.TrustDomain, witAuthorities map[str
 		trustDomain:    trustDomain,
 		witAuthorities: jwtutil.CopyJWTAuthorities(witAuthorities),
 	}
+}
+
+// Load loads a bundle from a file on disk. The file must contain a standard
+// RFC 7517 JWKS document.
+func Load(trustDomain spiffeid.TrustDomain, path string) (*Bundle, error) {
+	bundleBytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, wrapErr(fmt.Errorf("unable to read WIT bundle: %w", err))
+	}
+
+	return Parse(trustDomain, bundleBytes)
+}
+
+// Read decodes a bundle from a reader. The contents must contain a standard
+// RFC 7517 JWKS document.
+func Read(trustDomain spiffeid.TrustDomain, r io.Reader) (*Bundle, error) {
+	b, err := io.ReadAll(r)
+	if err != nil {
+		return nil, wrapErr(fmt.Errorf("unable to read: %v", err))
+	}
+
+	return Parse(trustDomain, b)
 }
 
 // Parse parses a bundle from a JWK Set JSON document.
@@ -82,6 +106,16 @@ func (b *Bundle) FindWITAuthority(keyID string) (crypto.PublicKey, bool) {
 	return nil, false
 }
 
+// HasWITAuthority returns true if the bundle has a WIT authority with the
+// given key ID.
+func (b *Bundle) HasWITAuthority(keyID string) bool {
+	b.mtx.RLock()
+	defer b.mtx.RUnlock()
+
+	_, ok := b.witAuthorities[keyID]
+	return ok
+}
+
 // AddWITAuthority adds a WIT authority to the bundle. If a WIT authority already
 // exists under the given key ID, it is replaced. A key ID must be specified.
 func (b *Bundle) AddWITAuthority(keyID string, witAuthority crypto.PublicKey) error {
@@ -94,6 +128,31 @@ func (b *Bundle) AddWITAuthority(keyID string, witAuthority crypto.PublicKey) er
 
 	b.witAuthorities[keyID] = witAuthority
 	return nil
+}
+
+// RemoveWITAuthority removes the WIT authority identified by the key ID from
+// the bundle.
+func (b *Bundle) RemoveWITAuthority(keyID string) {
+	b.mtx.Lock()
+	defer b.mtx.Unlock()
+
+	delete(b.witAuthorities, keyID)
+}
+
+// SetWITAuthorities sets the WIT authorities in the bundle.
+func (b *Bundle) SetWITAuthorities(witAuthorities map[string]crypto.PublicKey) {
+	b.mtx.Lock()
+	defer b.mtx.Unlock()
+
+	b.witAuthorities = jwtutil.CopyJWTAuthorities(witAuthorities)
+}
+
+// Empty returns true if the bundle has no WIT authorities.
+func (b *Bundle) Empty() bool {
+	b.mtx.RLock()
+	defer b.mtx.RUnlock()
+
+	return len(b.witAuthorities) == 0
 }
 
 // Marshal marshals the WIT bundle into a standard RFC 7517 JWKS document.
@@ -110,6 +169,24 @@ func (b *Bundle) Marshal() ([]byte, error) {
 	}
 
 	return json.Marshal(jwks)
+}
+
+// Clone clones the bundle.
+func (b *Bundle) Clone() *Bundle {
+	b.mtx.RLock()
+	defer b.mtx.RUnlock()
+
+	return FromWITAuthorities(b.trustDomain, b.witAuthorities)
+}
+
+// Equal compares the bundle for equality against the given bundle.
+func (b *Bundle) Equal(other *Bundle) bool {
+	if b == nil || other == nil {
+		return b == other
+	}
+
+	return b.trustDomain == other.trustDomain &&
+		jwtutil.JWTAuthoritiesEqual(b.witAuthorities, other.witAuthorities)
 }
 
 // GetWITBundleForTrustDomain returns the WIT bundle for the given trust domain.

--- a/exp/bundle/witbundle/bundle_test.go
+++ b/exp/bundle/witbundle/bundle_test.go
@@ -3,11 +3,13 @@ package witbundle_test
 import (
 	"crypto"
 	"encoding/json"
+	"os"
 	"testing"
 
 	"github.com/go-jose/go-jose/v4"
 	"github.com/spiffe/go-spiffe/v2/exp/bundle/witbundle"
 	"github.com/spiffe/go-spiffe/v2/internal/test"
+	"github.com/spiffe/go-spiffe/v2/internal/test/errstrings"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -69,6 +71,49 @@ func TestWITAuthority(t *testing.T) {
 		assert.False(t, ok)
 		assert.Nil(t, got)
 	})
+
+	t.Run("has", func(t *testing.T) {
+		b := witbundle.New(td)
+		require.NoError(t, b.AddWITAuthority("key-1", key1.Public()))
+		assert.True(t, b.HasWITAuthority("key-1"))
+		assert.False(t, b.HasWITAuthority("missing"))
+	})
+
+	t.Run("remove", func(t *testing.T) {
+		b := witbundle.New(td)
+		require.NoError(t, b.AddWITAuthority("key-1", key1.Public()))
+		require.NoError(t, b.AddWITAuthority("key-2", key2.Public()))
+
+		// Removing an unknown key ID is a no-op.
+		b.RemoveWITAuthority("missing")
+		assert.Len(t, b.WITAuthorities(), 2)
+
+		b.RemoveWITAuthority("key-2")
+		assert.Len(t, b.WITAuthorities(), 1)
+		assert.True(t, b.HasWITAuthority("key-1"))
+	})
+
+	t.Run("set replaces existing authorities", func(t *testing.T) {
+		b := witbundle.New(td)
+		require.NoError(t, b.AddWITAuthority("key-1", key1.Public()))
+
+		input := map[string]crypto.PublicKey{"key-2": key2.Public()}
+		b.SetWITAuthorities(input)
+		assert.Equal(t, input, b.WITAuthorities())
+
+		// Mutating the input map must not affect the bundle.
+		input["key-3"] = key1.Public()
+		assert.Len(t, b.WITAuthorities(), 1)
+	})
+}
+
+func TestEmpty(t *testing.T) {
+	b := witbundle.New(td)
+	assert.True(t, b.Empty())
+
+	key := test.NewEC256Key(t)
+	require.NoError(t, b.AddWITAuthority("key-1", key.Public()))
+	assert.False(t, b.Empty())
 }
 
 func TestWITAuthorities_DefensiveCopy(t *testing.T) {
@@ -114,6 +159,173 @@ func TestParse(t *testing.T) {
 		_, err = witbundle.Parse(td, data)
 		require.ErrorContains(t, err, "witbundle: error adding authority")
 	})
+}
+
+func TestLoad(t *testing.T) {
+	tests := []struct {
+		name          string
+		path          string
+		expectedCount int
+		expectedErr   string
+	}{
+		{
+			name:          "valid with one key",
+			path:          "testdata/jwks_valid_1.json",
+			expectedCount: 1,
+		},
+		{
+			name:          "valid with two keys",
+			path:          "testdata/jwks_valid_2.json",
+			expectedCount: 2,
+		},
+		{
+			name:        "non existent file",
+			path:        "testdata/does-not-exist.json",
+			expectedErr: "witbundle: unable to read WIT bundle: open testdata/does-not-exist.json: " + errstrings.FileNotFound,
+		},
+		{
+			name:        "missing kid",
+			path:        "testdata/jwks_missing_kid.json",
+			expectedErr: "witbundle: error adding authority 1 of JWKS: keyID cannot be empty",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, err := witbundle.Load(td, tt.path)
+			if tt.expectedErr != "" {
+				require.EqualError(t, err, tt.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, td, b.TrustDomain())
+			assert.Len(t, b.WITAuthorities(), tt.expectedCount)
+		})
+	}
+}
+
+func TestRead(t *testing.T) {
+	tests := []struct {
+		name          string
+		path          string
+		expectedCount int
+		expectedErr   string
+	}{
+		{
+			name:          "valid with one key",
+			path:          "testdata/jwks_valid_1.json",
+			expectedCount: 1,
+		},
+		{
+			name:          "valid with two keys",
+			path:          "testdata/jwks_valid_2.json",
+			expectedCount: 2,
+		},
+		{
+			name:        "unreadable reader",
+			path:        "testdata/does-not-exist.json",
+			expectedErr: "witbundle: unable to read: invalid argument",
+		},
+		{
+			name:        "missing kid",
+			path:        "testdata/jwks_missing_kid.json",
+			expectedErr: "witbundle: error adding authority 1 of JWKS: keyID cannot be empty",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// The Open call is expected to fail in the unreadable reader
+			// case, which makes Read fail when reading from the nil file.
+			file, _ := os.Open(tt.path)
+			defer file.Close()
+
+			b, err := witbundle.Read(td, file)
+			if tt.expectedErr != "" {
+				require.EqualError(t, err, tt.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, td, b.TrustDomain())
+			assert.Len(t, b.WITAuthorities(), tt.expectedCount)
+		})
+	}
+}
+
+func TestEqual(t *testing.T) {
+	key1 := test.NewEC256Key(t)
+	key2 := test.NewEC256Key(t)
+
+	empty := witbundle.New(td)
+	empty2 := witbundle.New(td2)
+
+	authorities1 := witbundle.FromWITAuthorities(td, map[string]crypto.PublicKey{"key-1": key1.Public()})
+	authorities2 := witbundle.FromWITAuthorities(td, map[string]crypto.PublicKey{"key-2": key2.Public()})
+
+	tests := []struct {
+		name        string
+		a           *witbundle.Bundle
+		b           *witbundle.Bundle
+		expectEqual bool
+	}{
+		{
+			name:        "empty equal",
+			a:           empty,
+			b:           empty,
+			expectEqual: true,
+		},
+		{
+			name:        "different trust domains",
+			a:           empty,
+			b:           empty2,
+			expectEqual: false,
+		},
+		{
+			name:        "WIT authorities equal",
+			a:           authorities1,
+			b:           authorities1,
+			expectEqual: true,
+		},
+		{
+			name:        "WIT authorities empty and not empty",
+			a:           empty,
+			b:           authorities1,
+			expectEqual: false,
+		},
+		{
+			name:        "WIT authorities not empty but not equal",
+			a:           authorities1,
+			b:           authorities2,
+			expectEqual: false,
+		},
+		{
+			name:        "nil and not nil",
+			a:           nil,
+			b:           empty,
+			expectEqual: false,
+		},
+		{
+			name:        "both nil",
+			a:           nil,
+			b:           nil,
+			expectEqual: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expectEqual, tt.a.Equal(tt.b))
+		})
+	}
+}
+
+func TestClone(t *testing.T) {
+	key := test.NewEC256Key(t)
+	original := witbundle.FromWITAuthorities(td, map[string]crypto.PublicKey{"key-1": key.Public()})
+
+	cloned := original.Clone()
+	require.True(t, original.Equal(cloned))
+
+	// Mutating the clone must not affect the original.
+	cloned.RemoveWITAuthority("key-1")
+	assert.True(t, original.HasWITAuthority("key-1"))
 }
 
 func TestGetWITBundleForTrustDomain(t *testing.T) {

--- a/exp/bundle/witbundle/testdata/jwks_missing_kid.json
+++ b/exp/bundle/witbundle/testdata/jwks_missing_kid.json
@@ -1,0 +1,17 @@
+{
+    "keys": [
+        {
+            "kty": "EC",
+            "kid": "C6vs25welZOx6WksNYfbMfiw9l96pMnD",
+            "crv": "P-256",
+            "x": "ngLYQnlfF6GsojUwqtcEE3WgTNG2RUlsGhK73RNEl5k",
+            "y": "tKbiDSUSsQ3F1P7wteeHNXIcU-cx6CgSbroeQrQHTLM"
+        },
+        {
+            "kty": "EC",
+            "crv": "P-256",
+            "x": "7MGOl06DP9df2u8oHY6lqYFIoQWzCj9UYlp-MFeEYeY",
+            "y": "PSLLy5Pg0_kNGFFXq_eeq9kYcGDM3MPHJ6ncteNOr6w"
+        }
+    ]
+}

--- a/exp/bundle/witbundle/testdata/jwks_valid_1.json
+++ b/exp/bundle/witbundle/testdata/jwks_valid_1.json
@@ -1,0 +1,11 @@
+{
+    "keys": [
+        {
+            "kty": "EC",
+            "kid": "C6vs25welZOx6WksNYfbMfiw9l96pMnD",
+            "crv": "P-256",
+            "x": "ngLYQnlfF6GsojUwqtcEE3WgTNG2RUlsGhK73RNEl5k",
+            "y": "tKbiDSUSsQ3F1P7wteeHNXIcU-cx6CgSbroeQrQHTLM"
+        }
+    ]
+}

--- a/exp/bundle/witbundle/testdata/jwks_valid_2.json
+++ b/exp/bundle/witbundle/testdata/jwks_valid_2.json
@@ -1,0 +1,18 @@
+{
+    "keys": [
+        {
+            "kty": "EC",
+            "kid": "C6vs25welZOx6WksNYfbMfiw9l96pMnD",
+            "crv": "P-256",
+            "x": "ngLYQnlfF6GsojUwqtcEE3WgTNG2RUlsGhK73RNEl5k",
+            "y": "tKbiDSUSsQ3F1P7wteeHNXIcU-cx6CgSbroeQrQHTLM"
+        },
+        {
+            "kty": "EC",
+            "kid": "gHTCunJbefYtnZnTctd84xeRWyMrEsWD",
+            "crv": "P-256",
+            "x": "7MGOl06DP9df2u8oHY6lqYFIoQWzCj9UYlp-MFeEYeY",
+            "y": "PSLLy5Pg0_kNGFFXq_eeq9kYcGDM3MPHJ6ncteNOr6w"
+        }
+    ]
+}


### PR DESCRIPTION
The experimental `witbundle` package added in #385 has a leaner API surface than its `jwtbundle` counterpart. It cannot load a bundle from a file or reader, and it lacks the mutation and comparison helpers available in the other bundle packages.

This PR adds the missing APIs so the two packages have the same surface: `Load`, `Read`, `HasWITAuthority`, `RemoveWITAuthority`, `SetWITAuthorities`, `Empty`, `Clone`, and `Equal`, mirroring their `jwtbundle` counterparts, along with tests.

This covers the remaining functionality from #367 that was not included in #385.
