### PR TITLE
Add wit-svid to marshaled WIT bundle keys

### DIFF
--- a/bundle/jwtbundle/bundle.go
+++ b/bundle/jwtbundle/bundle.go
@@ -154,7 +154,7 @@ func (b *Bundle) Marshal() ([]byte, error) {
 	b.mtx.RLock()
 	defer b.mtx.RUnlock()
 
-	jwks := jose.JSONWebKeySet{}
+	jwks := jose.JSONWebKeySet{Keys: make([]jose.JSONWebKey, 0, len(b.jwtAuthorities))}
 	for keyID, jwtAuthority := range b.jwtAuthorities {
 		jwks.Keys = append(jwks.Keys, jose.JSONWebKey{
 			Key:   jwtAuthority,

--- a/bundle/jwtbundle/bundle_test.go
+++ b/bundle/jwtbundle/bundle_test.go
@@ -2,6 +2,7 @@ package jwtbundle_test
 
 import (
 	"crypto"
+	"encoding/json"
 	"os"
 	"testing"
 
@@ -242,6 +243,17 @@ func TestMarshal(t *testing.T) {
 
 	// Assert that the marshaled bundle is equal to the parsed bundle
 	assert.Equal(t, bundleParsed, bundle)
+}
+
+func TestMarshalEmptyBundle(t *testing.T) {
+	data, err := jwtbundle.New(td).Marshal()
+	require.NoError(t, err)
+
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(data, &doc))
+	keys, ok := doc["keys"].([]any)
+	require.True(t, ok, "expected 'keys' to be a JSON array, not null")
+	assert.Empty(t, keys)
 }
 
 func TestGetJWTBundleForTrustDomain(t *testing.T) {

--- a/exp/bundle/witbundle/bundle.go
+++ b/exp/bundle/witbundle/bundle.go
@@ -16,6 +16,9 @@ import (
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 )
 
+// JWKUse is the JWK use value for WIT authorities in a JWKS document.
+const JWKUse = "wit-svid"
+
 // Bundle is a collection of trusted WIT authorities for a trust domain.
 type Bundle struct {
 	trustDomain spiffeid.TrustDomain
@@ -165,6 +168,7 @@ func (b *Bundle) Marshal() ([]byte, error) {
 		jwks.Keys = append(jwks.Keys, jose.JSONWebKey{
 			Key:   witAuthority,
 			KeyID: keyID,
+			Use:   JWKUse,
 		})
 	}
 

--- a/exp/bundle/witbundle/bundle.go
+++ b/exp/bundle/witbundle/bundle.go
@@ -163,7 +163,7 @@ func (b *Bundle) Marshal() ([]byte, error) {
 	b.mtx.RLock()
 	defer b.mtx.RUnlock()
 
-	jwks := jose.JSONWebKeySet{}
+	jwks := jose.JSONWebKeySet{Keys: make([]jose.JSONWebKey, 0, len(b.witAuthorities))}
 	for keyID, witAuthority := range b.witAuthorities {
 		jwks.Keys = append(jwks.Keys, jose.JSONWebKey{
 			Key:   witAuthority,

--- a/exp/bundle/witbundle/bundle.go
+++ b/exp/bundle/witbundle/bundle.go
@@ -16,8 +16,7 @@ import (
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 )
 
-// JWKUse is the JWK use value for WIT authorities in a JWKS document.
-const JWKUse = "wit-svid"
+const witSVIDUse = "wit-svid"
 
 // Bundle is a collection of trusted WIT authorities for a trust domain.
 type Bundle struct {
@@ -168,7 +167,7 @@ func (b *Bundle) Marshal() ([]byte, error) {
 		jwks.Keys = append(jwks.Keys, jose.JSONWebKey{
 			Key:   witAuthority,
 			KeyID: keyID,
-			Use:   JWKUse,
+			Use:   witSVIDUse,
 		})
 	}
 

--- a/exp/bundle/witbundle/bundle_test.go
+++ b/exp/bundle/witbundle/bundle_test.go
@@ -148,7 +148,7 @@ func TestMarshal(t *testing.T) {
 		}
 		var kids []string
 		for _, k := range jwks.Keys {
-			assert.Equal(t, witbundle.JWKUse, k.Use, "key %q missing expected use field", k.KeyID)
+			assert.Equal(t, "wit-svid", k.Use, "key %q missing expected use field", k.KeyID)
 			assert.Equal(t, wantKeys[k.KeyID], k.Key, "key material mismatch for %q", k.KeyID)
 			kids = append(kids, k.KeyID)
 		}

--- a/exp/bundle/witbundle/bundle_test.go
+++ b/exp/bundle/witbundle/bundle_test.go
@@ -160,9 +160,11 @@ func TestMarshal(t *testing.T) {
 		data, err := b.Marshal()
 		require.NoError(t, err)
 
-		var jwks jose.JSONWebKeySet
-		require.NoError(t, json.Unmarshal(data, &jwks))
-		assert.Empty(t, jwks.Keys)
+		var doc map[string]any
+		require.NoError(t, json.Unmarshal(data, &doc))
+		keys, ok := doc["keys"].([]any)
+		require.True(t, ok, "expected 'keys' to be a JSON array, not null")
+		assert.Empty(t, keys)
 	})
 }
 

--- a/exp/bundle/witbundle/bundle_test.go
+++ b/exp/bundle/witbundle/bundle_test.go
@@ -127,6 +127,45 @@ func TestWITAuthorities_DefensiveCopy(t *testing.T) {
 	assert.Len(t, b.WITAuthorities(), 1)
 }
 
+func TestMarshal(t *testing.T) {
+	t.Run("sets use field on every key", func(t *testing.T) {
+		key1 := test.NewEC256Key(t)
+		key2 := test.NewEC256Key(t)
+		b := witbundle.New(td)
+		require.NoError(t, b.AddWITAuthority("key-1", key1.Public()))
+		require.NoError(t, b.AddWITAuthority("key-2", key2.Public()))
+
+		data, err := b.Marshal()
+		require.NoError(t, err)
+
+		var jwks jose.JSONWebKeySet
+		require.NoError(t, json.Unmarshal(data, &jwks))
+		require.Len(t, jwks.Keys, 2)
+
+		wantKeys := map[string]crypto.PublicKey{
+			"key-1": key1.Public(),
+			"key-2": key2.Public(),
+		}
+		var kids []string
+		for _, k := range jwks.Keys {
+			assert.Equal(t, witbundle.JWKUse, k.Use, "key %q missing expected use field", k.KeyID)
+			assert.Equal(t, wantKeys[k.KeyID], k.Key, "key material mismatch for %q", k.KeyID)
+			kids = append(kids, k.KeyID)
+		}
+		assert.ElementsMatch(t, []string{"key-1", "key-2"}, kids)
+	})
+
+	t.Run("empty bundle produces empty keys array", func(t *testing.T) {
+		b := witbundle.New(td)
+		data, err := b.Marshal()
+		require.NoError(t, err)
+
+		var jwks jose.JSONWebKeySet
+		require.NoError(t, json.Unmarshal(data, &jwks))
+		assert.Empty(t, jwks.Keys)
+	})
+}
+
 func TestParse(t *testing.T) {
 	t.Run("round-trips with Marshal", func(t *testing.T) {
 		key1 := test.NewEC256Key(t)


### PR DESCRIPTION
The SPIFFE WIT spec (§6.1/§6.2) requires that each JWK entry in a WIT bundle JWKS document carry "use": "wit-svid".
 This field is how consuming clients distinguish WIT authorities from other keys that may coexist in a shared JWKS document. Without it, a client has no reliable way to identify which keys are valid WIT authorities.