### PR TITLE
Add WPT authentication for WIT-SVIDs

### DIFF
--- a/exp/svid/witsvid/source.go
+++ b/exp/svid/witsvid/source.go
@@ -2,8 +2,12 @@ package witsvid
 
 import "github.com/spiffe/go-spiffe/v2/spiffeid"
 
-// Source is a source of WIT-SVIDs keyed by SPIFFE ID.
+// Source is a source of WIT-SVIDs.
 type Source interface {
+	// GetWITSVID returns the default WIT-SVID from the source. It is used by
+	// code that presents a credential and therefore has no ID to look up.
+	GetWITSVID() (*SVID, error)
+
 	// GetWITSVIDForID returns the WIT-SVID for the given SPIFFE ID.
 	GetWITSVIDForID(id spiffeid.ID) (*SVID, error)
 }

--- a/exp/svid/witsvid/source.go
+++ b/exp/svid/witsvid/source.go
@@ -4,8 +4,7 @@ import "github.com/spiffe/go-spiffe/v2/spiffeid"
 
 // Source is a source of WIT-SVIDs.
 type Source interface {
-	// GetWITSVID returns the default WIT-SVID from the source. It is used by
-	// code that presents a credential and therefore has no ID to look up.
+	// GetWITSVID returns the default WIT-SVID from the source.
 	GetWITSVID() (*SVID, error)
 
 	// GetWITSVIDForID returns the WIT-SVID for the given SPIFFE ID.

--- a/exp/svid/witsvid/svid.go
+++ b/exp/svid/witsvid/svid.go
@@ -52,6 +52,9 @@ type SVID struct {
 	// identity should be used by a workload when more than one SVID is returned.
 	Hint string
 
+	// Claims is the parsed claims from the WIT-SVID token.
+	Claims map[string]interface{}
+
 	// token is the serialized JWS compact serialization.
 	token string
 }
@@ -167,6 +170,7 @@ func parse(token string, verify verifyFn) (*SVID, error) {
 		Expiry:    stdClaims.Expiry.Time().UTC(),
 		PublicKey: publicKey,
 		KeyID:     keyID,
+		Claims:    rawClaims,
 		token:     token,
 	}, nil
 }

--- a/exp/svid/witsvid/svid_test.go
+++ b/exp/svid/witsvid/svid_test.go
@@ -68,6 +68,20 @@ func TestParseInsecure(t *testing.T) {
 			}),
 		},
 		{
+			name: "issuer-supplied claims are exposed",
+			token: withClaims(func(c map[string]any) {
+				c["groups"] = []string{"admin", "ops"}
+			}),
+			check: func(t *testing.T, svid *witsvid.SVID) {
+				// Issuer-supplied claims are reachable by a verifier.
+				assert.Equal(t, []any{"admin", "ops"}, svid.Claims["groups"])
+				// Standard and confirmation claims come through untouched.
+				assert.Equal(t, workload.String(), svid.Claims["sub"])
+				assert.Contains(t, svid.Claims, "exp")
+				assert.Contains(t, svid.Claims, "cnf")
+			},
+		},
+		{
 			name:  "malformed",
 			token: func(*testing.T) string { return "not.a.valid.jwt" },
 			err:   "witsvid: unable to parse WIT-SVID token",

--- a/exp/withttp/audience.go
+++ b/exp/withttp/audience.go
@@ -7,8 +7,7 @@ import (
 )
 
 // Audience decides whether a proof's aud claim is acceptable for an incoming
-// request. It is a bare func type, so a deployment-specific rule the built-in
-// constructors cannot express is a type conversion rather than a new API:
+// request. A rule the constructors below cannot express is a type conversion:
 //
 //	withttp.Audience(func(r *http.Request, aud string) error { ... })
 type Audience func(r *http.Request, aud string) error
@@ -17,9 +16,9 @@ type Audience func(r *http.Request, aud string) error
 // ignoring the incoming request. Several values may be given for a proxied or
 // multi-homed deployment.
 //
-// This is the recommended mode. Because the expectation comes from
-// configuration rather than from the request, a legitimate receiver cannot
-// replay a proof it was given onward to a third party.
+// This is the recommended mode: because the expectation comes from configuration
+// rather than from the request, a legitimate receiver cannot replay a proof it
+// was given onward to a third party.
 func ExpectedAudience(values ...string) Audience {
 	// Normalized once here rather than per request.
 	matcher := witwpt.AcceptAudience(values...)
@@ -29,43 +28,28 @@ func ExpectedAudience(values ...string) Audience {
 }
 
 // UnsafeAudienceFromRequest matches a proof against the target URI reconstructed
-// from the incoming request, which needs no configuration.
+// from the incoming request, needing no configuration.
 //
-// # Do not use this unless you have read what it gives up
+// It reads r.Host, which draft-ietf-wimse-wpt-01 §3.1 forbids: allowed URL
+// authorities MUST come from a trusted source such as out-of-band configuration,
+// not from the request. The consequence is that a service legitimately receiving
+// a credential and proof can present the same pair onward to a third party while
+// claiming this authority, and that party will accept it.
 //
-// draft-ietf-wimse-wpt-01 §3.1 says a validator "MUST NOT use untrusted
-// information obtained from the request to determine if the hostname belongs to
-// an authorized authority", and continues: "The validator MUST get the
-// information about allowed URL authorities from a trusted source such as
-// out-of-band configuration. The Host of the request or an 'X-Forwarded-Host'
-// header is an example of untrusted data and cannot be trusted and MUST NOT be
-// used."
-//
-// This function reads r.Host. It therefore violates that requirement, and is
-// named Unsafe for exactly that reason. The practical consequence is that a
-// service which legitimately receives your credential and proof can present the
-// same pair onward to a third party while claiming your authority, and that third
-// party will accept it -- the proof is genuine, it simply was not meant for them.
-//
-// Use ExpectedAudience. It is one string of configuration and it closes this.
+// Prefer ExpectedAudience, which closes this.
 func UnsafeAudienceFromRequest() Audience {
 	return func(r *http.Request, aud string) error {
 		return witwpt.AcceptAudience(serverTargetURI(r))(aud)
 	}
 }
 
-// serverTargetURI reconstructs the request's target URI.
+// serverTargetURI reconstructs the request's target URI. Unlike an outbound
+// request, r.URL holds little more than the path, so the authority comes from
+// r.Host and the scheme from whether the connection was TLS. Forwarding headers
+// are never consulted.
 //
-// This is not the same computation the client performs. On an outbound request
-// req.URL is absolute, but the stdlib fills in almost nothing on an inbound one
-// -- "for most requests, fields other than Path and RawQuery will be empty" --
-// so the authority has to come from r.Host (the Host header under HTTP/1.1, the
-// :authority pseudo-header under HTTP/2) and the scheme from whether the
-// connection was TLS.
-//
-// It is unexported deliberately. Both inputs are attacker-supplied or
-// channel-derived rather than verified, so it must stay reachable only through// UnsafeAudienceFromRequest, whose documentation states that tradeoff. Forwarding
-// headers are never consulted.
+// It stays unexported because both inputs are unverified; UnsafeAudienceFromRequest
+// documents that tradeoff.
 func serverTargetURI(r *http.Request) string {
 	scheme := "http"
 	if r.TLS != nil {

--- a/exp/withttp/audience.go
+++ b/exp/withttp/audience.go
@@ -1,0 +1,75 @@
+package withttp
+
+import (
+	"net/http"
+
+	"github.com/spiffe/go-spiffe/v2/exp/witwpt"
+)
+
+// Audience decides whether a proof's aud claim is acceptable for an incoming
+// request. It is a bare func type, so a deployment-specific rule the built-in
+// constructors cannot express is a type conversion rather than a new API:
+//
+//	withttp.Audience(func(r *http.Request, aud string) error { ... })
+type Audience func(r *http.Request, aud string) error
+
+// ExpectedAudience matches a proof against the values this service answers to,
+// ignoring the incoming request. Several values may be given for a proxied or
+// multi-homed deployment.
+//
+// This is the recommended mode. Because the expectation comes from
+// configuration rather than from the request, a legitimate receiver cannot
+// replay a proof it was given onward to a third party.
+func ExpectedAudience(values ...string) Audience {
+	// Normalized once here rather than per request.
+	matcher := witwpt.AcceptAudience(values...)
+	return func(_ *http.Request, aud string) error {
+		return matcher(aud)
+	}
+}
+
+// UnsafeAudienceFromRequest matches a proof against the target URI reconstructed
+// from the incoming request, which needs no configuration.
+//
+// # Do not use this unless you have read what it gives up
+//
+// draft-ietf-wimse-wpt-01 §3.1 says a validator "MUST NOT use untrusted
+// information obtained from the request to determine if the hostname belongs to
+// an authorized authority", and continues: "The validator MUST get the
+// information about allowed URL authorities from a trusted source such as
+// out-of-band configuration. The Host of the request or an 'X-Forwarded-Host'
+// header is an example of untrusted data and cannot be trusted and MUST NOT be
+// used."
+//
+// This function reads r.Host. It therefore violates that requirement, and is
+// named Unsafe for exactly that reason. The practical consequence is that a
+// service which legitimately receives your credential and proof can present the
+// same pair onward to a third party while claiming your authority, and that third
+// party will accept it -- the proof is genuine, it simply was not meant for them.
+//
+// Use ExpectedAudience. It is one string of configuration and it closes this.
+func UnsafeAudienceFromRequest() Audience {
+	return func(r *http.Request, aud string) error {
+		return witwpt.AcceptAudience(serverTargetURI(r))(aud)
+	}
+}
+
+// serverTargetURI reconstructs the request's target URI.
+//
+// This is not the same computation the client performs. On an outbound request
+// req.URL is absolute, but the stdlib fills in almost nothing on an inbound one
+// -- "for most requests, fields other than Path and RawQuery will be empty" --
+// so the authority has to come from r.Host (the Host header under HTTP/1.1, the
+// :authority pseudo-header under HTTP/2) and the scheme from whether the
+// connection was TLS.
+//
+// It is unexported deliberately. Both inputs are attacker-supplied or
+// channel-derived rather than verified, so it must stay reachable only through// UnsafeAudienceFromRequest, whose documentation states that tradeoff. Forwarding
+// headers are never consulted.
+func serverTargetURI(r *http.Request) string {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	return scheme + "://" + r.Host + r.URL.EscapedPath()
+}

--- a/exp/withttp/audience_test.go
+++ b/exp/withttp/audience_test.go
@@ -1,0 +1,142 @@
+package withttp_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/exp/withttp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpectedAudience(t *testing.T) {
+	audience := withttp.ExpectedAudience("https://server.example.org")
+	request := httptest.NewRequest("GET", "https://server.example.org/v2/orders", nil)
+
+	t.Run("accepts a proof for the configured value", func(t *testing.T) {
+		require.NoError(t, audience(request, "https://server.example.org/v2/orders"))
+	})
+
+	t.Run("rejects a proof for another target", func(t *testing.T) {
+		err := audience(request, "https://elsewhere.example.org/v2/orders")
+		require.ErrorContains(t, err, "not accepted here")
+	})
+
+	t.Run("ignores the request entirely", func(t *testing.T) {
+		// Strict mode must not consult the request, or it would inherit the
+		// Host-spoofing weakness that UnsafeAudienceFromRequest documents.
+		spoofed := httptest.NewRequest("GET", "https://elsewhere.example.org/v2/orders", nil)
+		require.ErrorContains(t,
+			audience(spoofed, "https://elsewhere.example.org/v2/orders"), "not accepted here")
+	})
+
+	t.Run("accepts any of several configured values", func(t *testing.T) {
+		multi := withttp.ExpectedAudience("https://a.example.org", "https://b.example.org:8443")
+		require.NoError(t, multi(request, "https://b.example.org:8443/x"))
+	})
+}
+
+func TestUnsafeAudienceFromRequest(t *testing.T) {
+	audience := withttp.UnsafeAudienceFromRequest()
+
+	tests := []struct {
+		name     string
+		target   string
+		host     string
+		headers  map[string]string
+		aud      string
+		rejected bool
+	}{
+		{
+			name:   "derives scheme, authority and path from a TLS request",
+			target: "https://server.example.org/v2/orders",
+			aud:    "https://server.example.org/v2/orders",
+		},
+		{
+			name:   "normalization makes the path irrelevant",
+			target: "https://server.example.org/v2/orders",
+			aud:    "https://server.example.org/other",
+		},
+		{
+			name:   "preserves a non-default port",
+			target: "https://server.example.org:8443/v2/orders",
+			aud:    "https://server.example.org:8443/v2/orders",
+		},
+		{
+			name:     "a proof for another host is rejected",
+			target:   "https://server.example.org/v2/orders",
+			aud:      "https://elsewhere.example.org/v2/orders",
+			rejected: true,
+		},
+		{
+			name:     "a proof for another port is rejected",
+			target:   "https://server.example.org:8443/v2/orders",
+			aud:      "https://server.example.org:9443/v2/orders",
+			rejected: true,
+		},
+		{
+			name:   "X-Forwarded-Host is never consulted",
+			target: "https://server.example.org/v2/orders",
+			// wpt-01 §3.1 names X-Forwarded-Host as untrusted. A proof minted
+			// for the forwarded value must not be accepted.
+			headers:  map[string]string{"X-Forwarded-Host": "victim.example.org"},
+			aud:      "https://victim.example.org/v2/orders",
+			rejected: true,
+		},
+		{
+			name:     "X-Forwarded-Proto is never consulted",
+			target:   "https://server.example.org/v2/orders",
+			headers:  map[string]string{"X-Forwarded-Proto": "http"},
+			aud:      "http://server.example.org/v2/orders",
+			rejected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := httptest.NewRequest("GET", tt.target, nil)
+			for name, value := range tt.headers {
+				request.Header.Set(name, value)
+			}
+			if tt.host != "" {
+				request.Host = tt.host
+			}
+
+			err := audience(request, tt.aud)
+			if tt.rejected {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestUnsafeAudienceFromRequestDerivesHTTPWithoutTLS(t *testing.T) {
+	// Behind a TLS-terminating sidecar r.TLS is nil, so the derived scheme is
+	// http while the client, which required https before attaching tokens,
+	// minted an https audience. The combination therefore cannot match, which is
+	// why that topology wants ExpectedAudience instead.
+	audience := withttp.UnsafeAudienceFromRequest()
+	request := httptest.NewRequest("GET", "http://server.example.org/v2/orders", nil)
+	require.Nil(t, request.TLS, "precondition: plaintext request")
+
+	require.NoError(t, audience(request, "http://server.example.org/v2/orders"))
+	require.Error(t, audience(request, "https://server.example.org/v2/orders"))
+}
+
+func TestAudienceIsABareFuncType(t *testing.T) {
+	// The escape hatch is a type conversion, not a third constructor, so a
+	// deployment-specific rule needs nothing new from this package.
+	custom := withttp.Audience(func(r *http.Request, aud string) error {
+		if aud == "urn:internal:"+r.Host {
+			return nil
+		}
+		return errors.New("nope")
+	})
+
+	request := httptest.NewRequest("GET", "https://server.example.org/v2/orders", nil)
+	require.NoError(t, custom(request, "urn:internal:server.example.org"))
+	require.Error(t, custom(request, "urn:internal:other"))
+}

--- a/exp/withttp/helpers_test.go
+++ b/exp/withttp/helpers_test.go
@@ -1,0 +1,127 @@
+package withttp_test
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/spiffe/go-spiffe/v2/exp/bundle/witbundle"
+	"github.com/spiffe/go-spiffe/v2/exp/svid/witsvid"
+	"github.com/spiffe/go-spiffe/v2/internal/test"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/require"
+)
+
+const authorityKeyID = "authority-1"
+
+// fixture holds a matched WIT-SVID, its trust bundle, and the confirmation key,
+// so a test can act as either end of the exchange.
+type fixture struct {
+	bundle    *witbundle.Bundle
+	svid      *witsvid.SVID
+	authority *ecdsa.PrivateKey
+	cnfKey    *ecdsa.PrivateKey
+	id        spiffeid.ID
+}
+
+func newFixture(t *testing.T) *fixture {
+	t.Helper()
+
+	td := spiffeid.RequireTrustDomainFromString("example.org")
+	id := spiffeid.RequireFromPath(td, "/client")
+	authority := test.NewEC256Key(t)
+	cnfKey := test.NewEC256Key(t)
+
+	bundle := witbundle.New(td)
+	require.NoError(t, bundle.AddWITAuthority(authorityKeyID, authority.Public()))
+
+	token := makeWIT(t, authority, authorityKeyID, id, cnfKey.Public(), time.Now().Add(time.Hour))
+	svid, err := witsvid.ParseInsecure(token)
+	require.NoError(t, err)
+	svid.PrivateKey = cnfKey
+
+	return &fixture{bundle: bundle, svid: svid, authority: authority, cnfKey: cnfKey, id: id}
+}
+
+// makeWIT builds a WIT-SVID signed by authority.
+func makeWIT(t *testing.T, authority *ecdsa.PrivateKey, kid string, id spiffeid.ID,
+	cnfPub crypto.PublicKey, exp time.Time) string {
+	t.Helper()
+
+	cnfJWK := jose.JSONWebKey{Key: cnfPub, KeyID: "cnf-1", Algorithm: string(jose.ES256)}
+	cnfBytes, err := cnfJWK.MarshalJSON()
+	require.NoError(t, err)
+	var cnfMap map[string]any
+	require.NoError(t, json.Unmarshal(cnfBytes, &cnfMap))
+
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.ES256, Key: jose.JSONWebKey{Key: authority, KeyID: kid}},
+		(&jose.SignerOptions{}).WithType("wit+jwt"),
+	)
+	require.NoError(t, err)
+
+	token, err := jwt.Signed(signer).Claims(map[string]any{
+		"sub": id.String(),
+		"exp": jwt.NewNumericDate(exp),
+		"iat": jwt.NewNumericDate(time.Now()),
+		"cnf": map[string]any{"jwk": cnfMap},
+	}).Serialize()
+	require.NoError(t, err)
+	return token
+}
+
+// makeWPT builds a proof token locally, with full control over its claims, so
+// each verification rule can be violated in isolation. Middleware tests that
+// need a *valid* pair go through NewRoundTripper instead.
+// The typ header is fixed here: witwpt owns the rule that it must be wpt+jwt
+// and varies it in its own tests. These tests exercise the transport.
+func makeWPT(t *testing.T, key crypto.Signer, claims map[string]any) string {
+	t.Helper()
+
+	opts := (&jose.SignerOptions{}).WithType(jose.ContentType("wpt+jwt"))
+	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.ES256, Key: key}, opts)
+	require.NoError(t, err)
+
+	token, err := jwt.Signed(signer).Claims(claims).Serialize()
+	require.NoError(t, err)
+	return token
+}
+
+// staticSource serves one WIT-SVID, or an error.
+type staticSource struct {
+	svid *witsvid.SVID
+	err  error
+}
+
+func (s staticSource) GetWITSVID() (*witsvid.SVID, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.svid, nil
+}
+
+func (s staticSource) GetWITSVIDForID(spiffeid.ID) (*witsvid.SVID, error) {
+	return s.GetWITSVID()
+}
+
+// capturingTransport records the request it was handed instead of sending it.
+type capturingTransport struct {
+	got *http.Request
+}
+
+func (c *capturingTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	c.got = r
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       http.NoBody,
+		Request:    r,
+	}, nil
+}
+
+var errNoSVID = errors.New("no WIT-SVID available")

--- a/exp/withttp/middleware.go
+++ b/exp/withttp/middleware.go
@@ -26,11 +26,11 @@ type serverOption func(*serverConfig)
 func (fn serverOption) configureServer(c *serverConfig) { fn(c) }
 
 // WithErrorHandler registers a callback invoked with the reason a request was
-// rejected. The caller is told only that it was refused, so this is the only way
-// to observe an authentication failure.
+// rejected. Since the remote caller is told only that it was refused, this is
+// the only way to observe an authentication failure.
 //
-// Verification failures are *witwpt.Error and carry a Stage, which is suitable
-// as a metric dimension:
+// Verification failures are *witwpt.Error and carry a Stage suitable as a metric
+// dimension; an authorization failure carries no stage.
 //
 //	withttp.WithErrorHandler(func(r *http.Request, err error) {
 //	    var verr *witwpt.Error
@@ -38,9 +38,6 @@ func (fn serverOption) configureServer(c *serverConfig) { fn(c) }
 //	        metrics.Inc("wit_auth_rejected", verr.Stage.String())
 //	    }
 //	})
-//
-// An authorization failure carries no stage, since the middleware ran the
-// authorizer itself and already knows which step refused.
 func WithErrorHandler(handler func(r *http.Request, err error)) ServerOption {
 	return serverOption(func(c *serverConfig) {
 		c.onError = handler
@@ -52,17 +49,15 @@ func WithErrorHandler(handler func(r *http.Request, err error)) ServerOption {
 // credential in the request context for PeerSVIDFromContext.
 //
 // audience is a required argument because there is no safe default: accepting
-// any audience would let a service replay a proof it received onward to this
-// one. Omitting it is a compile error rather than a silent weakening.
+// any audience would let a service replay onward a proof it received.
 //
-// Every rejection is answered with 403 and an empty body. Distinct codes per
-// failure would form an oracle telling a caller how far a forgery progressed,
-// and 401 is unavailable regardless -- draft-ietf-wimse-workload-creds §5.2
-// rules out the WWW-Authenticate challenge flow for the WIT. Register
-// WithErrorHandler to see why a request was refused.
+// Every rejection is answered with 403 and an empty body, so no response
+// reveals how far a forgery progressed. 401 is not used because
+// draft-ietf-wimse-workload-creds §5.2 rules out the WWW-Authenticate challenge
+// flow for the WIT. Register WithErrorHandler to see why a request was refused.
 //
-// By default a request arriving over a channel that is not TLS is rejected
-// before any token work; see WithTrustedTransport.
+// A request arriving over a non-TLS channel is rejected before any token work;
+// see WithTrustedTransport.
 func Middleware(verifier *witwpt.Verifier, audience Audience, authorizer witwpt.Authorizer,
 	opts ...ServerOption) func(http.Handler) http.Handler {
 	config := &serverConfig{}
@@ -86,9 +81,9 @@ func Middleware(verifier *witwpt.Verifier, audience Audience, authorizer witwpt.
 	}
 }
 
-// exactlyOne returns the single value of a header, rejecting both absence and
-// duplication. An empty string is returned with no error when the header is
-// absent, so the core reports the missing token with its own message.
+// exactlyOne returns the single value of a header, rejecting duplication. An
+// absent header returns an empty string and no error, leaving witwpt to report
+// the missing token.
 func exactlyOne(r *http.Request, name string) (string, error) {
 	values := r.Header.Values(name)
 	switch len(values) {
@@ -101,15 +96,12 @@ func exactlyOne(r *http.Request, name string) (string, error) {
 	}
 }
 
-// forHandler returns the request to pass on: the verified credential in the
-// context, and the raw tokens removed.
+// forHandler returns the request to pass on, with the verified credential in the
+// context and the raw tokens stripped.
 //
-// Stripping them matters because a handler that proxies onward -- httputil.
-// ReverseProxy, or any client copying inbound headers -- would otherwise forward
-// the credential and a still-valid proof verbatim, performing an onward replay by
-// accident. Since a proof's audience is authority-scoped, a third party sharing
-// the authority would accept it. Nothing needs the raw tokens once verification
-// has produced the SVID.
+// The tokens are stripped because a handler that proxies onward, such as
+// httputil.ReverseProxy, would otherwise forward the credential and a
+// still-valid proof verbatim and replay it by accident.
 func forHandler(r *http.Request, svid *witsvid.SVID) *http.Request {
 	// Clone so the caller's request is left as it was.
 	out := r.Clone(withPeerSVID(r.Context(), svid))
@@ -120,10 +112,8 @@ func forHandler(r *http.Request, svid *witsvid.SVID) *http.Request {
 
 func authenticate(r *http.Request, verifier *witwpt.Verifier, audience Audience,
 	authorizer witwpt.Authorizer, config *serverConfig) (*witsvid.SVID, error) {
-	// The channel is a property of the connection, not of the tokens, so it is
-	// checked here rather than in the transport-neutral core. r.TLS == nil covers
-	// both plaintext and TLS-terminated-upstream, which are indistinguishable
-	// from here -- hence the explicit opt-out rather than a guess.
+	// r.TLS == nil covers both plaintext and TLS terminated upstream, which are
+	// indistinguishable here, hence the explicit opt-out.
 	if r.TLS == nil && !config.trustedTransport {
 		return nil, wrapErr(errors.New(
 			"refusing to authenticate over a non-TLS channel; assert WithTrustedTransport " +
@@ -131,8 +121,8 @@ func authenticate(r *http.Request, verifier *witwpt.Verifier, audience Audience,
 	}
 
 	// wpt-01 §2 step 1: exactly one of each. Taking only the first field line
-	// would let a request that an intermediary reads as a comma-joined list be
-	// parsed differently here, which is how header smuggling gets in.
+	// would parse a duplicated header differently than an intermediary that
+	// comma-joins it, which is how header smuggling gets in.
 	witToken, err := exactlyOne(r, HeaderWIT)
 	if err != nil {
 		return nil, &witwpt.Error{Stage: witwpt.StageWIT, Err: err}
@@ -142,7 +132,7 @@ func authenticate(r *http.Request, verifier *witwpt.Verifier, audience Audience,
 		return nil, &witwpt.Error{Stage: witwpt.StageProof, Err: err}
 	}
 
-	// Bind this request into the core's transport-neutral matcher.
+	// Bind this request into witwpt's transport-neutral matcher.
 	matcher := witwpt.AudienceMatcher(func(aud string) error {
 		return audience(r, aud)
 	})
@@ -152,8 +142,8 @@ func authenticate(r *http.Request, verifier *witwpt.Verifier, audience Audience,
 		return nil, err
 	}
 
-	// Authorization is a separate step from authentication: Verify answers "who
-	// is this, provably", and policy is a different question.
+	// Authorization is a separate step: Verify establishes who the peer is, not
+	// whether policy admits it.
 	if err := authorizer(svid); err != nil {
 		return nil, wrapErr(err)
 	}
@@ -169,10 +159,9 @@ func withPeerSVID(ctx context.Context, svid *witsvid.SVID) context.Context {
 }
 
 // PeerSVIDFromContext returns the verified WIT-SVID of the peer that made the
-// request, for a handler wrapped by Middleware.
-//
-// It returns an error when the handler was not wrapped, rather than a zero value
-// that would read as an authenticated peer.
+// request, for a handler wrapped by Middleware. It returns an error when the
+// handler was not wrapped, rather than a zero value reading as an authenticated
+// peer.
 func PeerSVIDFromContext(ctx context.Context) (*witsvid.SVID, error) {
 	svid, ok := ctx.Value(peerSVIDKey{}).(*witsvid.SVID)
 	if !ok || svid == nil {
@@ -181,9 +170,8 @@ func PeerSVIDFromContext(ctx context.Context) (*witsvid.SVID, error) {
 	return svid, nil
 }
 
-// PeerIDFromContext returns the SPIFFE ID of the peer that made the request. It
-// is a convenience over PeerSVIDFromContext for handlers that need only the
-// identity.
+// PeerIDFromContext returns the SPIFFE ID of the peer that made the request, a
+// convenience over PeerSVIDFromContext for handlers needing only the identity.
 func PeerIDFromContext(ctx context.Context) (spiffeid.ID, error) {
 	svid, err := PeerSVIDFromContext(ctx)
 	if err != nil {

--- a/exp/withttp/middleware.go
+++ b/exp/withttp/middleware.go
@@ -1,0 +1,193 @@
+package withttp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/spiffe/go-spiffe/v2/exp/svid/witsvid"
+	"github.com/spiffe/go-spiffe/v2/exp/witwpt"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+)
+
+// ServerOption configures the server side of WIT authentication.
+type ServerOption interface {
+	configureServer(*serverConfig)
+}
+
+type serverConfig struct {
+	trustedTransport bool
+	onError          func(*http.Request, error)
+}
+
+type serverOption func(*serverConfig)
+
+func (fn serverOption) configureServer(c *serverConfig) { fn(c) }
+
+// WithErrorHandler registers a callback invoked with the reason a request was
+// rejected. The caller is told only that it was refused, so this is the only way
+// to observe an authentication failure.
+//
+// Verification failures are *witwpt.Error and carry a Stage, which is suitable
+// as a metric dimension:
+//
+//	withttp.WithErrorHandler(func(r *http.Request, err error) {
+//	    var verr *witwpt.Error
+//	    if errors.As(err, &verr) {
+//	        metrics.Inc("wit_auth_rejected", verr.Stage.String())
+//	    }
+//	})
+//
+// An authorization failure carries no stage, since the middleware ran the
+// authorizer itself and already knows which step refused.
+func WithErrorHandler(handler func(r *http.Request, err error)) ServerOption {
+	return serverOption(func(c *serverConfig) {
+		c.onError = handler
+	})
+}
+
+// Middleware returns a decorator that authenticates each request's WIT-SVID and
+// proof against verifier, authorizes the peer, and places the verified
+// credential in the request context for PeerSVIDFromContext.
+//
+// audience is a required argument because there is no safe default: accepting
+// any audience would let a service replay a proof it received onward to this
+// one. Omitting it is a compile error rather than a silent weakening.
+//
+// Every rejection is answered with 403 and an empty body. Distinct codes per
+// failure would form an oracle telling a caller how far a forgery progressed,
+// and 401 is unavailable regardless -- draft-ietf-wimse-workload-creds §5.2
+// rules out the WWW-Authenticate challenge flow for the WIT. Register
+// WithErrorHandler to see why a request was refused.
+//
+// By default a request arriving over a channel that is not TLS is rejected
+// before any token work; see WithTrustedTransport.
+func Middleware(verifier *witwpt.Verifier, audience Audience, authorizer witwpt.Authorizer,
+	opts ...ServerOption) func(http.Handler) http.Handler {
+	config := &serverConfig{}
+	for _, opt := range opts {
+		opt.configureServer(config)
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			svid, err := authenticate(r, verifier, audience, authorizer, config)
+			if err != nil {
+				if config.onError != nil {
+					config.onError(r, err)
+				}
+				// Uniform, detail-free rejection.
+				w.WriteHeader(http.StatusForbidden)
+				return
+			}
+			next.ServeHTTP(w, forHandler(r, svid))
+		})
+	}
+}
+
+// exactlyOne returns the single value of a header, rejecting both absence and
+// duplication. An empty string is returned with no error when the header is
+// absent, so the core reports the missing token with its own message.
+func exactlyOne(r *http.Request, name string) (string, error) {
+	values := r.Header.Values(name)
+	switch len(values) {
+	case 0:
+		return "", nil
+	case 1:
+		return values[0], nil
+	default:
+		return "", fmt.Errorf("expected exactly one %s header, got %d", name, len(values))
+	}
+}
+
+// forHandler returns the request to pass on: the verified credential in the
+// context, and the raw tokens removed.
+//
+// Stripping them matters because a handler that proxies onward -- httputil.
+// ReverseProxy, or any client copying inbound headers -- would otherwise forward
+// the credential and a still-valid proof verbatim, performing an onward replay by
+// accident. Since a proof's audience is authority-scoped, a third party sharing
+// the authority would accept it. Nothing needs the raw tokens once verification
+// has produced the SVID.
+func forHandler(r *http.Request, svid *witsvid.SVID) *http.Request {
+	// Clone so the caller's request is left as it was.
+	out := r.Clone(withPeerSVID(r.Context(), svid))
+	out.Header.Del(HeaderWIT)
+	out.Header.Del(HeaderProof)
+	return out
+}
+
+func authenticate(r *http.Request, verifier *witwpt.Verifier, audience Audience,
+	authorizer witwpt.Authorizer, config *serverConfig) (*witsvid.SVID, error) {
+	// The channel is a property of the connection, not of the tokens, so it is
+	// checked here rather than in the transport-neutral core. r.TLS == nil covers
+	// both plaintext and TLS-terminated-upstream, which are indistinguishable
+	// from here -- hence the explicit opt-out rather than a guess.
+	if r.TLS == nil && !config.trustedTransport {
+		return nil, wrapErr(errors.New(
+			"refusing to authenticate over a non-TLS channel; assert WithTrustedTransport " +
+				"if a secure channel is provided by other means"))
+	}
+
+	// wpt-01 §2 step 1: exactly one of each. Taking only the first field line
+	// would let a request that an intermediary reads as a comma-joined list be
+	// parsed differently here, which is how header smuggling gets in.
+	witToken, err := exactlyOne(r, HeaderWIT)
+	if err != nil {
+		return nil, &witwpt.Error{Stage: witwpt.StageWIT, Err: err}
+	}
+	proofToken, err := exactlyOne(r, HeaderProof)
+	if err != nil {
+		return nil, &witwpt.Error{Stage: witwpt.StageProof, Err: err}
+	}
+
+	// Bind this request into the core's transport-neutral matcher.
+	matcher := witwpt.AudienceMatcher(func(aud string) error {
+		return audience(r, aud)
+	})
+
+	svid, err := verifier.Verify(r.Context(), witToken, proofToken, matcher)
+	if err != nil {
+		return nil, err
+	}
+
+	// Authorization is a separate step from authentication: Verify answers "who
+	// is this, provably", and policy is a different question.
+	if err := authorizer(svid); err != nil {
+		return nil, wrapErr(err)
+	}
+	return svid, nil
+}
+
+// peerSVIDKey is unexported so no other package can place a value the accessors
+// below would trust.
+type peerSVIDKey struct{}
+
+func withPeerSVID(ctx context.Context, svid *witsvid.SVID) context.Context {
+	return context.WithValue(ctx, peerSVIDKey{}, svid)
+}
+
+// PeerSVIDFromContext returns the verified WIT-SVID of the peer that made the
+// request, for a handler wrapped by Middleware.
+//
+// It returns an error when the handler was not wrapped, rather than a zero value
+// that would read as an authenticated peer.
+func PeerSVIDFromContext(ctx context.Context) (*witsvid.SVID, error) {
+	svid, ok := ctx.Value(peerSVIDKey{}).(*witsvid.SVID)
+	if !ok || svid == nil {
+		return nil, wrapErr(errors.New("no verified WIT-SVID in context"))
+	}
+	return svid, nil
+}
+
+// PeerIDFromContext returns the SPIFFE ID of the peer that made the request. It
+// is a convenience over PeerSVIDFromContext for handlers that need only the
+// identity.
+func PeerIDFromContext(ctx context.Context) (spiffeid.ID, error) {
+	svid, err := PeerSVIDFromContext(ctx)
+	if err != nil {
+		return spiffeid.ID{}, err
+	}
+	return svid.ID, nil
+}

--- a/exp/withttp/middleware_test.go
+++ b/exp/withttp/middleware_test.go
@@ -1,0 +1,422 @@
+package withttp_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/spiffe/go-spiffe/v2/exp/svid/witsvid"
+	"github.com/spiffe/go-spiffe/v2/exp/withttp"
+	"github.com/spiffe/go-spiffe/v2/exp/witwpt"
+	"github.com/spiffe/go-spiffe/v2/internal/test"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const serverAudience = "https://server.example.org"
+
+// validProofClaims returns proof claims that should verify against f.
+func (f *fixture) validProofClaims() map[string]any {
+	return map[string]any{
+		"aud": serverAudience + "/v2/orders",
+		"exp": jwt.NewNumericDate(time.Now().Add(witwpt.DefaultProofLifetime)),
+		"jti": "jti-middleware-0001",
+		"wth": witwpt.WITThumbprint(f.svid.Marshal()),
+	}
+}
+
+// serve runs the middleware over a recording handler and returns the response.
+func serve(t *testing.T, f *fixture, witToken, proof string,
+	opts ...withttp.ServerOption) (*httptest.ResponseRecorder, bool) {
+	t.Helper()
+
+	var reached bool
+	handler := withttp.Middleware(
+		witwpt.NewVerifier(f.bundle),
+		withttp.ExpectedAudience(serverAudience),
+		witwpt.AuthorizeAny(),
+		opts...,
+	)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		reached = true
+	}))
+
+	request := httptest.NewRequest("GET", serverAudience+"/v2/orders", nil)
+	if witToken != "" {
+		request.Header.Set(withttp.HeaderWIT, witToken)
+	}
+	if proof != "" {
+		request.Header.Set(withttp.HeaderProof, proof)
+	}
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, request)
+	return recorder, reached
+}
+
+func TestMiddlewareAcceptsAValidPair(t *testing.T) {
+	f := newFixture(t)
+	proof := makeWPT(t, f.cnfKey, f.validProofClaims())
+
+	recorder, reached := serve(t, f, f.svid.Marshal(), proof)
+
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	assert.True(t, reached, "the handler must run")
+}
+
+func TestMiddlewareAnswers403ForEveryFailure(t *testing.T) {
+	// One status for every stage, deliberately. Distinct codes for "malformed
+	// token", "audience mismatch", and "authorizer denied" would form an oracle
+	// telling a caller how far a forgery progressed. 401 is unavailable anyway:
+	// workload-creds §5.2 rules out the WWW-Authenticate flow for the WIT.
+	tests := []struct {
+		name  string
+		stage witwpt.Stage
+		wit   func(*testing.T, *fixture) string
+		proof func(*testing.T, *fixture) string
+	}{
+		{
+			name:  "both tokens missing",
+			stage: witwpt.StageWIT,
+			wit:   func(*testing.T, *fixture) string { return "" },
+			proof: func(*testing.T, *fixture) string { return "" },
+		},
+		{
+			name:  "proof missing",
+			stage: witwpt.StageProof,
+			proof: func(*testing.T, *fixture) string { return "" },
+		},
+		{
+			name:  "credential missing",
+			stage: witwpt.StageWIT,
+			wit:   func(*testing.T, *fixture) string { return "" },
+		},
+		{
+			name:  "proof signed by an unrelated key",
+			stage: witwpt.StageProof,
+			proof: func(t *testing.T, f *fixture) string {
+				return makeWPT(t, test.NewEC256Key(t), f.validProofClaims())
+			},
+		},
+		{
+			name:  "proof bound to a different credential",
+			stage: witwpt.StageProof,
+			proof: func(t *testing.T, f *fixture) string {
+				claims := f.validProofClaims()
+				claims["wth"] = witwpt.WITThumbprint("some other token")
+				return makeWPT(t, f.cnfKey, claims)
+			},
+		},
+		{
+			name:  "proof for another audience",
+			stage: witwpt.StageProof,
+			proof: func(t *testing.T, f *fixture) string {
+				claims := f.validProofClaims()
+				claims["aud"] = "https://elsewhere.example.org/v2/orders"
+				return makeWPT(t, f.cnfKey, claims)
+			},
+		},
+		{
+			name:  "expired proof",
+			stage: witwpt.StageProof,
+			proof: func(t *testing.T, f *fixture) string {
+				claims := f.validProofClaims()
+				claims["exp"] = jwt.NewNumericDate(time.Now().Add(-time.Hour))
+				return makeWPT(t, f.cnfKey, claims)
+			},
+		},
+		{
+			name:  "expired credential",
+			stage: witwpt.StageWIT,
+			wit: func(t *testing.T, f *fixture) string {
+				return makeWIT(t, f.authority, authorityKeyID, f.id, f.cnfKey.Public(),
+					time.Now().Add(-time.Hour))
+			},
+		},
+		{
+			name:  "credential from an untrusted authority",
+			stage: witwpt.StageWIT,
+			wit: func(t *testing.T, f *fixture) string {
+				return makeWIT(t, test.NewEC256Key(t), authorityKeyID, f.id,
+					f.cnfKey.Public(), time.Now().Add(time.Hour))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newFixture(t)
+
+			witToken := f.svid.Marshal()
+			if tt.wit != nil {
+				witToken = tt.wit(t, f)
+			}
+
+			// Rebuild the proof against whichever credential is being sent, so
+			// only the property under test is wrong.
+			claims := f.validProofClaims()
+			claims["wth"] = witwpt.WITThumbprint(witToken)
+			proof := makeWPT(t, f.cnfKey, claims)
+			if tt.proof != nil {
+				proof = tt.proof(t, f)
+			}
+
+			var handled error
+			recorder, reached := serve(t, f, witToken, proof,
+				withttp.WithErrorHandler(func(_ *http.Request, err error) { handled = err }))
+
+			assert.Equal(t, http.StatusForbidden, recorder.Code)
+			assert.False(t, reached, "the handler must not run")
+			assert.Empty(t, recorder.Body.String(), "no detail may leak to the caller")
+
+			require.Error(t, handled, "the operator's handler must receive the reason")
+			var verr *witwpt.Error
+			require.ErrorAs(t, handled, &verr)
+			assert.Equal(t, tt.stage, verr.Stage)
+		})
+	}
+}
+
+func TestMiddlewareAuthorizerDenial(t *testing.T) {
+	f := newFixture(t)
+	proof := makeWPT(t, f.cnfKey, f.validProofClaims())
+
+	var handled error
+	var reached bool
+	stranger := spiffeid.RequireFromString("spiffe://example.org/someone-else")
+
+	handler := withttp.Middleware(
+		witwpt.NewVerifier(f.bundle),
+		withttp.ExpectedAudience(serverAudience),
+		witwpt.AuthorizeID(stranger),
+		withttp.WithErrorHandler(func(_ *http.Request, err error) { handled = err }),
+	)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { reached = true }))
+
+	request := httptest.NewRequest("GET", serverAudience+"/v2/orders", nil)
+	request.Header.Set(withttp.HeaderWIT, f.svid.Marshal())
+	request.Header.Set(withttp.HeaderProof, proof)
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, request)
+
+	assert.Equal(t, http.StatusForbidden, recorder.Code)
+	assert.False(t, reached)
+	require.Error(t, handled)
+
+	// Authorization failures carry no stage: the middleware ran the authorizer
+	// itself and already knows which step refused.
+	var verr *witwpt.Error
+	assert.False(t, errors.As(handled, &verr), "an authorizer denial is not a verification stage")
+}
+
+func TestMiddlewarePlacesTheCredentialInContext(t *testing.T) {
+	f := newFixture(t)
+	proof := makeWPT(t, f.cnfKey, f.validProofClaims())
+
+	var (
+		gotSVID *witsvid.SVID
+		gotID   spiffeid.ID
+	)
+	handler := withttp.Middleware(
+		witwpt.NewVerifier(f.bundle),
+		withttp.ExpectedAudience(serverAudience),
+		witwpt.AuthorizeAny(),
+	)(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		var err error
+		gotSVID, err = withttp.PeerSVIDFromContext(r.Context())
+		require.NoError(t, err)
+		gotID, err = withttp.PeerIDFromContext(r.Context())
+		require.NoError(t, err)
+	}))
+
+	request := httptest.NewRequest("GET", serverAudience+"/v2/orders", nil)
+	request.Header.Set(withttp.HeaderWIT, f.svid.Marshal())
+	request.Header.Set(withttp.HeaderProof, proof)
+	handler.ServeHTTP(httptest.NewRecorder(), request)
+
+	require.NotNil(t, gotSVID, "the whole verified credential must reach the handler")
+	assert.Equal(t, f.id, gotSVID.ID)
+	assert.Equal(t, f.id, gotID)
+	assert.Contains(t, gotSVID.Claims, "cnf")
+}
+
+func TestMiddlewareRequiresExactlyOneOfEachToken(t *testing.T) {
+	// wpt-01 §2 step 1 requires exactly one proof. Reading only the first field
+	// line would diverge from an intermediary that comma-joins repeated values,
+	// which is the classic shape of a header-smuggling bug.
+	f := newFixture(t)
+	valid := makeWPT(t, f.cnfKey, f.validProofClaims())
+
+	tests := []struct {
+		name   string
+		wits   []string
+		proofs []string
+		stage  witwpt.Stage
+	}{
+		{
+			name:   "two proofs, the first valid",
+			wits:   []string{f.svid.Marshal()},
+			proofs: []string{valid, "second-value"},
+			stage:  witwpt.StageProof,
+		},
+		{
+			name:   "two credentials, the first valid",
+			wits:   []string{f.svid.Marshal(), "second-value"},
+			proofs: []string{valid},
+			stage:  witwpt.StageWIT,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var handled error
+			handler := withttp.Middleware(
+				witwpt.NewVerifier(f.bundle),
+				withttp.ExpectedAudience(serverAudience),
+				witwpt.AuthorizeAny(),
+				withttp.WithErrorHandler(func(_ *http.Request, err error) { handled = err }),
+			)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				t.Error("the handler must not run")
+			}))
+
+			request := httptest.NewRequest("GET", serverAudience+"/v2/orders", nil)
+			for _, v := range tt.wits {
+				request.Header.Add(withttp.HeaderWIT, v)
+			}
+			for _, v := range tt.proofs {
+				request.Header.Add(withttp.HeaderProof, v)
+			}
+
+			recorder := httptest.NewRecorder()
+			handler.ServeHTTP(recorder, request)
+
+			assert.Equal(t, http.StatusForbidden, recorder.Code)
+			require.Error(t, handled)
+			var verr *witwpt.Error
+			require.ErrorAs(t, handled, &verr)
+			assert.Equal(t, tt.stage, verr.Stage)
+		})
+	}
+}
+
+func TestMiddlewareStripsTheTokensBeforeTheHandler(t *testing.T) {
+	// A handler that proxies onward -- httputil.ReverseProxy, or any client that
+	// copies inbound headers -- would otherwise forward the credential and a
+	// still-valid proof verbatim, performing an onward replay by accident. The
+	// verified credential is already in the context, so the raw tokens have no
+	// remaining use.
+	f := newFixture(t)
+	proof := makeWPT(t, f.cnfKey, f.validProofClaims())
+
+	var gotWIT, gotProof string
+	var svidReachedHandler bool
+	handler := withttp.Middleware(
+		witwpt.NewVerifier(f.bundle),
+		withttp.ExpectedAudience(serverAudience),
+		witwpt.AuthorizeAny(),
+	)(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		gotWIT = r.Header.Get(withttp.HeaderWIT)
+		gotProof = r.Header.Get(withttp.HeaderProof)
+		_, err := withttp.PeerSVIDFromContext(r.Context())
+		svidReachedHandler = err == nil
+	}))
+
+	request := httptest.NewRequest("GET", serverAudience+"/v2/orders", nil)
+	request.Header.Set(withttp.HeaderWIT, f.svid.Marshal())
+	request.Header.Set(withttp.HeaderProof, proof)
+	handler.ServeHTTP(httptest.NewRecorder(), request)
+
+	assert.Empty(t, gotWIT, "the credential must not reach the handler as a header")
+	assert.Empty(t, gotProof, "the proof must not reach the handler as a header")
+	assert.True(t, svidReachedHandler, "but the verified credential must still be available")
+}
+
+func TestPeerFromContextWithoutMiddleware(t *testing.T) {
+	// A handler that was not wrapped must get an error, never a zero-value ID
+	// that would read as an authenticated peer.
+	_, err := withttp.PeerSVIDFromContext(t.Context())
+	require.Error(t, err)
+
+	_, err = withttp.PeerIDFromContext(t.Context())
+	require.Error(t, err)
+}
+
+func TestMiddlewareRequiresASecureChannel(t *testing.T) {
+	f := newFixture(t)
+	proof := makeWPT(t, f.cnfKey, f.validProofClaims())
+
+	newHandler := func(opts ...withttp.ServerOption) http.Handler {
+		return withttp.Middleware(
+			witwpt.NewVerifier(f.bundle),
+			withttp.ExpectedAudience(serverAudience),
+			witwpt.AuthorizeAny(),
+			opts...,
+		)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusTeapot)
+		}))
+	}
+
+	request := func() *http.Request {
+		r := httptest.NewRequest("GET", serverAudience+"/v2/orders", nil)
+		r.Header.Set(withttp.HeaderWIT, f.svid.Marshal())
+		r.Header.Set(withttp.HeaderProof, proof)
+		r.TLS = nil // plaintext, or TLS terminated upstream -- indistinguishable
+		return r
+	}
+
+	t.Run("plaintext is refused by default", func(t *testing.T) {
+		// Default-on catches the real misconfiguration: a service listening in
+		// plaintext while believing it authenticates WIT-SVIDs.
+		recorder := httptest.NewRecorder()
+		newHandler().ServeHTTP(recorder, request())
+		assert.Equal(t, http.StatusForbidden, recorder.Code)
+	})
+
+	t.Run("WithTrustedTransport allows it", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		newHandler(withttp.WithTrustedTransport()).ServeHTTP(recorder, request())
+		assert.Equal(t, http.StatusTeapot, recorder.Code, "the handler must run")
+	})
+}
+
+// TestEndToEnd is the one place the client and server halves meet. Everything
+// else pins each half against something outside itself.
+func TestEndToEnd(t *testing.T) {
+	f := newFixture(t)
+
+	var peerID spiffeid.ID
+	handler := withttp.Middleware(
+		witwpt.NewVerifier(f.bundle, witwpt.WithReplayCache(witwpt.NewMemoryReplayCache())),
+		withttp.UnsafeAudienceFromRequest(),
+		witwpt.AuthorizeMemberOf(f.id.TrustDomain()),
+	)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id, err := withttp.PeerIDFromContext(r.Context())
+		require.NoError(t, err)
+		peerID = id
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	server := httptest.NewTLSServer(handler)
+	defer server.Close()
+
+	client := server.Client()
+	client.Transport = withttp.NewRoundTripper(staticSource{svid: f.svid}, client.Transport)
+
+	resp, err := client.Get(server.URL + "/v2/orders")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusNoContent, resp.StatusCode,
+		"a client-minted proof must satisfy the server's verifier")
+	assert.Equal(t, f.id, peerID)
+
+	// A second request must also succeed: each carries its own jti, so the
+	// replay cache does not reject legitimate traffic.
+	resp2, err := client.Get(server.URL + "/v2/orders")
+	require.NoError(t, err)
+	defer resp2.Body.Close()
+	assert.Equal(t, http.StatusNoContent, resp2.StatusCode)
+}

--- a/exp/withttp/roundtripper.go
+++ b/exp/withttp/roundtripper.go
@@ -4,13 +4,12 @@
 // A client wraps its transport with NewRoundTripper, which attaches the
 // credential and a freshly minted proof to every request. A server wraps its
 // handler with Middleware, which verifies both, authorizes the peer, and places
-// the verified credential in the request context. Neither side's calling code
-// names a header, hashes a token, or orders a verification step.
+// the verified credential in the request context.
 //
 // The WIT-SVID and its proof must travel over a server-authenticated TLS
-// connection (draft-ietf-wimse-workload-creds §9.5). That channel is the
-// existing X.509 machinery in spiffetls/tlsconfig, unchanged: this package
-// composes over a caller-supplied transport rather than building one.
+// connection (draft-ietf-wimse-workload-creds §9.5). That channel remains the
+// caller's own: this package composes over a supplied transport rather than
+// building one.
 package withttp
 
 import (
@@ -22,12 +21,9 @@ import (
 )
 
 const (
-	// HeaderWIT carries the WIT-SVID's compact serialization. Registered as
-	// "Workload-Identity-Token" by draft-ietf-wimse-workload-creds §5.1.1.
-	//
-	// Note the credential MUST NOT be sent in the Authorization header, and a
-	// rejection MUST NOT be answered with 401: both would imply the bearer-token
-	// semantics the WIT-SVID exists to avoid.
+	// HeaderWIT carries the WIT-SVID's compact serialization, per
+	// draft-ietf-wimse-workload-creds §5.1.1. The credential MUST NOT be sent in
+	// the Authorization header, which would imply bearer-token semantics.
 	HeaderWIT = "Workload-Identity-Token"
 
 	// HeaderProof carries the Workload Proof Token's compact serialization,
@@ -45,13 +41,11 @@ type clientConfig struct {
 }
 
 // WithTrustedTransport asserts that the channel is secure even though it is not
-// https, and is required to attach tokens over a plaintext hop.
+// https, and is required to send or accept tokens over a plaintext hop.
 //
-// Use it only where a secure channel is genuinely provided by other means -- a
-// sidecar that terminates TLS and forwards over loopback, which is the drafts'
-// "unless a secure channel is provided by some other mechanism". This package
-// cannot detect its misuse, so it is named for the precondition it asserts
-// rather than for the check it skips.
+// Use it only where a secure channel is genuinely provided by other means, such
+// as a sidecar that terminates TLS and forwards over loopback. Misuse cannot be
+// detected here.
 func WithTrustedTransport() interface {
 	ClientOption
 	ServerOption
@@ -59,8 +53,8 @@ func WithTrustedTransport() interface {
 	return trustedTransportOption{}
 }
 
-// trustedTransportOption satisfies both option types, so one name means one
-// thing on either side of the wire.
+// trustedTransportOption satisfies both option types, so the one name works on
+// either side of the wire.
 type trustedTransportOption struct{}
 
 func (trustedTransportOption) configureClient(c *clientConfig) { c.trustedTransport = true }
@@ -68,14 +62,10 @@ func (trustedTransportOption) configureServer(c *serverConfig) { c.trustedTransp
 
 // NewRoundTripper returns an http.RoundTripper that attaches the source's
 // WIT-SVID and a freshly minted proof to every request, then delegates to base.
+// A nil base means http.DefaultTransport.
 //
-// A nil base means http.DefaultTransport. Passing the base rather than a
-// *tls.Config keeps the TLS channel visibly the caller's own, so this package
-// forms no opinion about timeouts, proxies, or pooling, and composes with a
-// tracing or retry transport.
-//
-// A proof is minted per request rather than cached: signing costs tens of
-// microseconds, and a fresh proof keeps the replay window at its floor.
+// A proof is minted per request rather than cached, which keeps the replay
+// window at its floor.
 func NewRoundTripper(source witsvid.Source, base http.RoundTripper,
 	opts ...ClientOption) http.RoundTripper {
 	config := &clientConfig{}
@@ -92,8 +82,8 @@ type roundTripper struct {
 }
 
 func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	// The channel is checked before anything else, so a misconfigured client
-	// fails rather than leaking a credential over plaintext.
+	// Checked first, so a misconfigured client fails rather than leaking a
+	// credential over plaintext.
 	if req.URL.Scheme != "https" && !rt.config.trustedTransport {
 		return nil, wrapErr(fmt.Errorf(
 			"refusing to attach a WIT-SVID over %q; use https or assert WithTrustedTransport",
@@ -126,16 +116,12 @@ func (rt *roundTripper) transport() http.RoundTripper {
 }
 
 // clientTargetURI returns the proof's aud value for an outbound request: the
-// RFC 9110 target URI without query or fragment, which is the SHOULD value in
-// wpt-01 §2.
-//
-// Unlike the server side this is a trim rather than a reconstruction, because
-// req.URL is already absolute on an outbound request.
+// RFC 9110 target URI without query or fragment, per wpt-01 §2. It is a trim
+// rather than a reconstruction, since req.URL is already absolute here.
 func clientTargetURI(req *http.Request) string {
 	target := *req.URL
-	// net/http retains URL.User for the Authorization header, so it has to be
-	// cleared explicitly: otherwise a password ends up inside a signed token on
-	// the wire, and in any log line reporting an audience mismatch.
+	// Userinfo is cleared so a password does not end up inside a signed token or
+	// in a log line reporting an audience mismatch.
 	target.User = nil
 	target.RawQuery = ""
 	target.Fragment = ""

--- a/exp/withttp/roundtripper.go
+++ b/exp/withttp/roundtripper.go
@@ -1,0 +1,148 @@
+// Package withttp authenticates net/http requests with WIT-SVIDs, using the
+// Workload Proof Token protocol from exp/witwpt.
+//
+// A client wraps its transport with NewRoundTripper, which attaches the
+// credential and a freshly minted proof to every request. A server wraps its
+// handler with Middleware, which verifies both, authorizes the peer, and places
+// the verified credential in the request context. Neither side's calling code
+// names a header, hashes a token, or orders a verification step.
+//
+// The WIT-SVID and its proof must travel over a server-authenticated TLS
+// connection (draft-ietf-wimse-workload-creds §9.5). That channel is the
+// existing X.509 machinery in spiffetls/tlsconfig, unchanged: this package
+// composes over a caller-supplied transport rather than building one.
+package withttp
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/spiffe/go-spiffe/v2/exp/svid/witsvid"
+	"github.com/spiffe/go-spiffe/v2/exp/witwpt"
+)
+
+const (
+	// HeaderWIT carries the WIT-SVID's compact serialization. Registered as
+	// "Workload-Identity-Token" by draft-ietf-wimse-workload-creds §5.1.1.
+	//
+	// Note the credential MUST NOT be sent in the Authorization header, and a
+	// rejection MUST NOT be answered with 401: both would imply the bearer-token
+	// semantics the WIT-SVID exists to avoid.
+	HeaderWIT = "Workload-Identity-Token"
+
+	// HeaderProof carries the Workload Proof Token's compact serialization,
+	// per draft-ietf-wimse-wpt-01 §2.
+	HeaderProof = "Workload-Proof-Token"
+)
+
+// ClientOption configures the client side of WIT authentication.
+type ClientOption interface {
+	configureClient(*clientConfig)
+}
+
+type clientConfig struct {
+	trustedTransport bool
+}
+
+// WithTrustedTransport asserts that the channel is secure even though it is not
+// https, and is required to attach tokens over a plaintext hop.
+//
+// Use it only where a secure channel is genuinely provided by other means -- a
+// sidecar that terminates TLS and forwards over loopback, which is the drafts'
+// "unless a secure channel is provided by some other mechanism". This package
+// cannot detect its misuse, so it is named for the precondition it asserts
+// rather than for the check it skips.
+func WithTrustedTransport() interface {
+	ClientOption
+	ServerOption
+} {
+	return trustedTransportOption{}
+}
+
+// trustedTransportOption satisfies both option types, so one name means one
+// thing on either side of the wire.
+type trustedTransportOption struct{}
+
+func (trustedTransportOption) configureClient(c *clientConfig) { c.trustedTransport = true }
+func (trustedTransportOption) configureServer(c *serverConfig) { c.trustedTransport = true }
+
+// NewRoundTripper returns an http.RoundTripper that attaches the source's
+// WIT-SVID and a freshly minted proof to every request, then delegates to base.
+//
+// A nil base means http.DefaultTransport. Passing the base rather than a
+// *tls.Config keeps the TLS channel visibly the caller's own, so this package
+// forms no opinion about timeouts, proxies, or pooling, and composes with a
+// tracing or retry transport.
+//
+// A proof is minted per request rather than cached: signing costs tens of
+// microseconds, and a fresh proof keeps the replay window at its floor.
+func NewRoundTripper(source witsvid.Source, base http.RoundTripper,
+	opts ...ClientOption) http.RoundTripper {
+	config := &clientConfig{}
+	for _, opt := range opts {
+		opt.configureClient(config)
+	}
+	return &roundTripper{source: source, base: base, config: *config}
+}
+
+type roundTripper struct {
+	source witsvid.Source
+	base   http.RoundTripper
+	config clientConfig
+}
+
+func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	// The channel is checked before anything else, so a misconfigured client
+	// fails rather than leaking a credential over plaintext.
+	if req.URL.Scheme != "https" && !rt.config.trustedTransport {
+		return nil, wrapErr(fmt.Errorf(
+			"refusing to attach a WIT-SVID over %q; use https or assert WithTrustedTransport",
+			req.URL.Scheme))
+	}
+
+	svid, err := rt.source.GetWITSVID()
+	if err != nil {
+		return nil, wrapErr(err)
+	}
+
+	proof, err := witwpt.Mint(svid, clientTargetURI(req))
+	if err != nil {
+		return nil, wrapErr(err)
+	}
+
+	// RoundTrip must not modify the request it is given.
+	req = req.Clone(req.Context())
+	req.Header.Set(HeaderWIT, svid.Marshal())
+	req.Header.Set(HeaderProof, proof)
+
+	return rt.transport().RoundTrip(req)
+}
+
+func (rt *roundTripper) transport() http.RoundTripper {
+	if rt.base != nil {
+		return rt.base
+	}
+	return http.DefaultTransport
+}
+
+// clientTargetURI returns the proof's aud value for an outbound request: the
+// RFC 9110 target URI without query or fragment, which is the SHOULD value in
+// wpt-01 §2.
+//
+// Unlike the server side this is a trim rather than a reconstruction, because
+// req.URL is already absolute on an outbound request.
+func clientTargetURI(req *http.Request) string {
+	target := *req.URL
+	// net/http retains URL.User for the Authorization header, so it has to be
+	// cleared explicitly: otherwise a password ends up inside a signed token on
+	// the wire, and in any log line reporting an audience mismatch.
+	target.User = nil
+	target.RawQuery = ""
+	target.Fragment = ""
+	target.RawFragment = ""
+	return target.String()
+}
+
+func wrapErr(err error) error {
+	return fmt.Errorf("withttp: %w", err)
+}

--- a/exp/withttp/roundtripper_test.go
+++ b/exp/withttp/roundtripper_test.go
@@ -1,0 +1,198 @@
+package withttp_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/spiffe/go-spiffe/v2/exp/withttp"
+	"github.com/spiffe/go-spiffe/v2/exp/witwpt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoundTripperAttachesBothTokens(t *testing.T) {
+	f := newFixture(t)
+	base := &capturingTransport{}
+	rt := withttp.NewRoundTripper(staticSource{svid: f.svid}, base)
+
+	request := httptest.NewRequest("GET", "https://server.example.org/v2/orders?page=2", nil)
+	resp, err := rt.RoundTrip(request)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotNil(t, base.got)
+
+	t.Run("the WIT-SVID travels verbatim in its own header", func(t *testing.T) {
+		assert.Equal(t, f.svid.Marshal(), base.got.Header.Get(withttp.HeaderWIT))
+	})
+
+	t.Run("neither token uses the Authorization header", func(t *testing.T) {
+		// workload-creds §5.1: the WIT "is not intended for use in the
+		// Authorization header".
+		assert.Empty(t, base.got.Header.Get("Authorization"))
+	})
+
+	t.Run("the proof is bound to this credential and target", func(t *testing.T) {
+		proof := base.got.Header.Get(withttp.HeaderProof)
+		require.NotEmpty(t, proof)
+
+		tok, err := jwt.ParseSigned(proof, []jose.SignatureAlgorithm{jose.ES256})
+		require.NoError(t, err)
+
+		var claims map[string]any
+		require.NoError(t, tok.Claims(f.cnfKey.Public(), &claims))
+
+		assert.Equal(t, witwpt.WITThumbprint(f.svid.Marshal()), claims["wth"])
+		// aud is the target URI without query or fragment (wpt-01 §2).
+		assert.Equal(t, "https://server.example.org/v2/orders", claims["aud"])
+	})
+}
+
+func TestRoundTripperKeepsCredentialsOutOfTheAudience(t *testing.T) {
+	// net/http keeps URL.User for the Authorization header, so a URL carrying
+	// userinfo would otherwise put a password inside a signed token on the wire --
+	// and into any log line that reports an audience mismatch.
+	f := newFixture(t)
+	base := &capturingTransport{}
+	rt := withttp.NewRoundTripper(staticSource{svid: f.svid}, base)
+
+	request := httptest.NewRequest("GET",
+		"https://alice:s3cr3t@server.example.org/v2/orders?page=2#top", nil)
+	resp, err := rt.RoundTrip(request)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	tok, err := jwt.ParseSigned(base.got.Header.Get(withttp.HeaderProof),
+		[]jose.SignatureAlgorithm{jose.ES256})
+	require.NoError(t, err)
+	var claims map[string]any
+	require.NoError(t, tok.Claims(f.cnfKey.Public(), &claims))
+
+	assert.Equal(t, "https://server.example.org/v2/orders", claims["aud"])
+	assert.NotContains(t, claims["aud"], "s3cr3t")
+	assert.NotContains(t, claims["aud"], "alice")
+}
+
+func TestRoundTripperDoesNotMutateTheCallersRequest(t *testing.T) {
+	// http.RoundTripper's contract forbids modifying the request it is given.
+	f := newFixture(t)
+	base := &capturingTransport{}
+	rt := withttp.NewRoundTripper(staticSource{svid: f.svid}, base)
+
+	request := httptest.NewRequest("GET", "https://server.example.org/v2/orders", nil)
+	resp, err := rt.RoundTrip(request)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Empty(t, request.Header.Get(withttp.HeaderWIT),
+		"the caller's request must be left untouched")
+	assert.Empty(t, request.Header.Get(withttp.HeaderProof))
+	assert.NotSame(t, request, base.got, "a clone should be sent")
+}
+
+func TestRoundTripperMintsAFreshProofPerRequest(t *testing.T) {
+	f := newFixture(t)
+	base := &capturingTransport{}
+	rt := withttp.NewRoundTripper(staticSource{svid: f.svid}, base)
+
+	proofs := make(map[string]struct{})
+	for range 5 {
+		request := httptest.NewRequest("GET", "https://server.example.org/v2/orders", nil)
+		resp, err := rt.RoundTrip(request)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+		proofs[base.got.Header.Get(withttp.HeaderProof)] = struct{}{}
+	}
+	assert.Len(t, proofs, 5, "each request must carry its own proof")
+}
+
+func TestRoundTripperRequiresASecureChannel(t *testing.T) {
+	f := newFixture(t)
+
+	t.Run("plaintext is refused and nothing is sent", func(t *testing.T) {
+		// workload-creds §9.5 and wpt §3.1 both require a server-authenticated
+		// TLS connection.
+		base := &capturingTransport{}
+		rt := withttp.NewRoundTripper(staticSource{svid: f.svid}, base)
+
+		request := httptest.NewRequest("GET", "http://server.example.org/v2/orders", nil)
+		resp, err := rt.RoundTrip(request) //nolint:bodyclose // no response on the error path
+
+		require.ErrorContains(t, err, "https")
+		require.Nil(t, resp)
+		assert.Nil(t, base.got, "the request must not reach the wire")
+	})
+
+	t.Run("WithTrustedTransport allows a plaintext hop", func(t *testing.T) {
+		base := &capturingTransport{}
+		rt := withttp.NewRoundTripper(staticSource{svid: f.svid}, base,
+			withttp.WithTrustedTransport())
+
+		request := httptest.NewRequest("GET", "http://server.example.org/v2/orders", nil)
+		resp, err := rt.RoundTrip(request)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+		require.NotNil(t, base.got)
+		assert.NotEmpty(t, base.got.Header.Get(withttp.HeaderWIT))
+	})
+}
+
+func TestRoundTripperPropagatesSourceFailure(t *testing.T) {
+	base := &capturingTransport{}
+	rt := withttp.NewRoundTripper(staticSource{err: errNoSVID}, base)
+
+	request := httptest.NewRequest("GET", "https://server.example.org/v2/orders", nil)
+	resp, err := rt.RoundTrip(request) //nolint:bodyclose // no response on the error path
+
+	require.ErrorIs(t, err, errNoSVID)
+	require.Nil(t, resp, "no response may be returned alongside an error")
+	assert.Nil(t, base.got)
+}
+
+func TestRoundTripperOverRealTLS(t *testing.T) {
+	// Composing over the caller's base transport is the point: the TLS channel
+	// stays the existing machinery rather than something this package rebuilds.
+	f := newFixture(t)
+
+	var gotWIT string
+	server := httptest.NewTLSServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		gotWIT = r.Header.Get(withttp.HeaderWIT)
+	}))
+	defer server.Close()
+
+	client := server.Client()
+	client.Transport = withttp.NewRoundTripper(staticSource{svid: f.svid}, client.Transport)
+
+	resp, err := client.Get(server.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, f.svid.Marshal(), gotWIT)
+}
+
+func TestRoundTripperNilBaseUsesDefaultTransport(t *testing.T) {
+	// A nil base means http.DefaultTransport. Proven by actually completing a
+	// request through it rather than by inspecting a field.
+	f := newFixture(t)
+
+	var gotWIT string
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		gotWIT = r.Header.Get(withttp.HeaderWIT)
+	}))
+	defer server.Close()
+
+	// Plaintext, so the trusted-transport assertion is required here.
+	rt := withttp.NewRoundTripper(staticSource{svid: f.svid}, nil, withttp.WithTrustedTransport())
+
+	request, err := http.NewRequestWithContext(t.Context(), "GET", server.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := rt.RoundTrip(request)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, f.svid.Marshal(), gotWIT)
+}

--- a/exp/witwpt/audience.go
+++ b/exp/witwpt/audience.go
@@ -1,0 +1,110 @@
+package witwpt
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// AudienceMatcher decides whether a WPT's aud claim is acceptable for this
+// request. It is called with the aud claim exactly as it appeared in the proof.
+type AudienceMatcher func(aud string) error
+
+// AcceptAudience returns an AudienceMatcher that matches aud against values,
+// normalizing both sides to scheme and authority.
+//
+// draft-ietf-wimse-wpt-01 §2 requires that aud "matches the target URI, or an
+// acceptable alias or normalization thereof, of the HTTP request in which the WPT
+// was received, ignoring any query and fragment parts". Normalization here
+// lowercases the scheme and host, drops a port that is the default for the
+// scheme, and discards the query and fragment.
+//
+// # Proofs are scoped to an authority, not to a resource
+//
+// This also discards the PATH, on both sides. The draft names query and fragment
+// explicitly and leaves path handling to what counts as an "acceptable alias or
+// normalization", so this is a deliberate reading rather than something the draft
+// spells out. gRPC forces it in any case, since grpc-go's client-side audience is
+// per-service.
+//
+// The consequence is a security tradeoff worth stating plainly: a proof is bound
+// to an authority, not to a route or a method. Any endpoint sharing a hostname
+// can present a captured pair to any other endpoint on that hostname for the
+// proof's lifetime. WithReplayCache narrows that; a path in a configured value
+// does NOT, because it is ignored -- ExpectedAudience("https://api.example.org/a")
+// also accepts a proof minted for /b.
+//
+// A value that cannot be normalized is retained verbatim, so it never matches a
+// normalized audience and appears in the mismatch error for diagnosis.
+func AcceptAudience(values ...string) AudienceMatcher {
+	accepted := make([]string, 0, len(values))
+	for _, value := range values {
+		normalized, err := normalizeAudience(value)
+		if err != nil {
+			normalized = value
+		}
+		accepted = append(accepted, normalized)
+	}
+
+	return func(aud string) error {
+		if aud == "" {
+			return wrapErr(errors.New("proof is missing the aud claim"))
+		}
+
+		normalized, err := normalizeAudience(aud)
+		if err != nil {
+			return wrapErr(fmt.Errorf("proof audience %q is not a valid absolute URI", aud))
+		}
+
+		for _, candidate := range accepted {
+			if normalized == candidate {
+				return nil
+			}
+		}
+
+		// Both values are named so a proxy or port misconfiguration is
+		// diagnosable from a single log line.
+		return wrapErr(fmt.Errorf("proof audience %q is not accepted here (expected one of %q)",
+			aud, accepted))
+	}
+}
+
+// normalizeAudience reduces an absolute URI to scheme://authority, dropping the
+// default port for the scheme along with any path, query, and fragment.
+func normalizeAudience(value string) (string, error) {
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return "", err
+	}
+
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme == "" || parsed.Host == "" {
+		return "", fmt.Errorf("not an absolute URI: %q", value)
+	}
+
+	host := strings.ToLower(parsed.Hostname())
+	if host == "" {
+		return "", fmt.Errorf("no host in %q", value)
+	}
+
+	if port := parsed.Port(); port != "" && !isDefaultPort(scheme, port) {
+		host = host + ":" + port
+	}
+	return scheme + "://" + host, nil
+}
+
+func isDefaultPort(scheme, port string) bool {
+	switch scheme {
+	case "https":
+		return port == "443"
+	case "http":
+		return port == "80"
+	default:
+		return false
+	}
+}
+
+func wrapErr(err error) error {
+	return fmt.Errorf("witwpt: %w", err)
+}

--- a/exp/witwpt/audience.go
+++ b/exp/witwpt/audience.go
@@ -12,31 +12,16 @@ import (
 type AudienceMatcher func(aud string) error
 
 // AcceptAudience returns an AudienceMatcher that matches aud against values,
-// normalizing both sides to scheme and authority.
+// normalizing both sides to scheme and authority as wpt-01 §2's "acceptable
+// alias or normalization" allows: the scheme and host are lowercased, and a
+// default port, path, query, and fragment are dropped.
 //
-// draft-ietf-wimse-wpt-01 §2 requires that aud "matches the target URI, or an
-// acceptable alias or normalization thereof, of the HTTP request in which the WPT
-// was received, ignoring any query and fragment parts". Normalization here
-// lowercases the scheme and host, drops a port that is the default for the
-// scheme, and discards the query and fragment.
+// Dropping the path means a proof is bound to an authority, not to a route, so
+// any endpoint on that hostname accepts a captured pair for the proof's
+// lifetime; WithReplayCache narrows that, a path in a configured value does not.
 //
-// # Proofs are scoped to an authority, not to a resource
-//
-// This also discards the PATH, on both sides. The draft names query and fragment
-// explicitly and leaves path handling to what counts as an "acceptable alias or
-// normalization", so this is a deliberate reading rather than something the draft
-// spells out. gRPC forces it in any case, since grpc-go's client-side audience is
-// per-service.
-//
-// The consequence is a security tradeoff worth stating plainly: a proof is bound
-// to an authority, not to a route or a method. Any endpoint sharing a hostname
-// can present a captured pair to any other endpoint on that hostname for the
-// proof's lifetime. WithReplayCache narrows that; a path in a configured value
-// does NOT, because it is ignored -- ExpectedAudience("https://api.example.org/a")
-// also accepts a proof minted for /b.
-//
-// A value that cannot be normalized is retained verbatim, so it never matches a
-// normalized audience and appears in the mismatch error for diagnosis.
+// A value that cannot be normalized is kept verbatim, so it never matches and
+// still appears in the mismatch error.
 func AcceptAudience(values ...string) AudienceMatcher {
 	accepted := make([]string, 0, len(values))
 	for _, value := range values {
@@ -63,8 +48,8 @@ func AcceptAudience(values ...string) AudienceMatcher {
 			}
 		}
 
-		// Both values are named so a proxy or port misconfiguration is
-		// diagnosable from a single log line.
+		// Both sides are named so a proxy or port misconfiguration is diagnosable
+		// from one log line.
 		return wrapErr(fmt.Errorf("proof audience %q is not accepted here (expected one of %q)",
 			aud, accepted))
 	}

--- a/exp/witwpt/audience_test.go
+++ b/exp/witwpt/audience_test.go
@@ -1,0 +1,132 @@
+package witwpt_test
+
+import (
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/exp/witwpt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAcceptAudience(t *testing.T) {
+	tests := []struct {
+		name     string
+		accepted []string
+		aud      string
+		err      string
+	}{
+		{
+			name:     "exact match",
+			accepted: []string{"https://server.example.org"},
+			aud:      "https://server.example.org",
+		},
+		{
+			name:     "path on the received audience is ignored",
+			accepted: []string{"https://server.example.org"},
+			aud:      "https://server.example.org/v2/orders",
+		},
+		{
+			name:     "query and fragment on the received audience are ignored",
+			accepted: []string{"https://server.example.org"},
+			aud:      "https://server.example.org/v2/orders?page=2#top",
+		},
+		{
+			name:     "path on the configured value is ignored",
+			accepted: []string{"https://server.example.org/v2/"},
+			aud:      "https://server.example.org/v2/orders",
+		},
+		{
+			name:     "trailing slash on either side is ignored",
+			accepted: []string{"https://server.example.org/"},
+			aud:      "https://server.example.org",
+		},
+		{
+			name:     "default https port is dropped from the received audience",
+			accepted: []string{"https://server.example.org"},
+			aud:      "https://server.example.org:443/v2/orders",
+		},
+		{
+			name:     "default https port is dropped from the configured value",
+			accepted: []string{"https://server.example.org:443"},
+			aud:      "https://server.example.org",
+		},
+		{
+			name:     "default http port is dropped",
+			accepted: []string{"http://server.example.org"},
+			aud:      "http://server.example.org:80/health",
+		},
+		{
+			name:     "scheme and host compare case-insensitively",
+			accepted: []string{"https://Server.Example.ORG"},
+			aud:      "HTTPS://server.example.org",
+		},
+		{
+			name:     "non-default port must match",
+			accepted: []string{"https://server.example.org:50051"},
+			aud:      "https://server.example.org:50051/helloworld.Greeter",
+		},
+		{
+			name:     "one of several configured values matches",
+			accepted: []string{"https://a.example.org", "https://b.example.org"},
+			aud:      "https://b.example.org/api",
+		},
+		{
+			name:     "different host is rejected",
+			accepted: []string{"https://b.example.org"},
+			aud:      "https://a.example.org",
+			err: `witwpt: proof audience "https://a.example.org" is not accepted here ` +
+				`(expected one of ["https://b.example.org"])`,
+		},
+		{
+			name:     "different port is rejected",
+			accepted: []string{"https://server.example.org:8443"},
+			aud:      "https://server.example.org:9443",
+			err: `witwpt: proof audience "https://server.example.org:9443" is not accepted here ` +
+				`(expected one of ["https://server.example.org:8443"])`,
+		},
+		{
+			name:     "different scheme is rejected",
+			accepted: []string{"https://server.example.org"},
+			aud:      "http://server.example.org",
+			err: `witwpt: proof audience "http://server.example.org" is not accepted here ` +
+				`(expected one of ["https://server.example.org"])`,
+		},
+		{
+			name:     "empty audience is rejected",
+			accepted: []string{"https://server.example.org"},
+			aud:      "",
+			err:      "witwpt: proof is missing the aud claim",
+		},
+		{
+			name:     "audience without a scheme is rejected",
+			accepted: []string{"https://server.example.org"},
+			aud:      "server.example.org",
+			err:      `witwpt: proof audience "server.example.org" is not a valid absolute URI`,
+		},
+		{
+			name:     "no configured values accepts nothing",
+			accepted: nil,
+			aud:      "https://server.example.org",
+			err: `witwpt: proof audience "https://server.example.org" is not accepted here ` +
+				`(expected one of [])`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := witwpt.AcceptAudience(tt.accepted...)(tt.aud)
+			if tt.err != "" {
+				require.EqualError(t, err, tt.err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestAcceptAudienceReportsMalformedConfiguredValue(t *testing.T) {
+	// A configured value the library cannot normalize must never match, and the
+	// error has to show the operator what they configured so it is diagnosable.
+	err := witwpt.AcceptAudience("not a uri")("https://server.example.org")
+	assert.ErrorContains(t, err, `"not a uri"`)
+}

--- a/exp/witwpt/authorizer.go
+++ b/exp/witwpt/authorizer.go
@@ -1,0 +1,51 @@
+package witwpt
+
+import (
+	"errors"
+
+	"github.com/spiffe/go-spiffe/v2/exp/svid/witsvid"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+)
+
+// Authorizer decides whether an authenticated peer may proceed. It runs after
+// verification has succeeded, so the SVID it receives is one whose proof of
+// possession was checked against the trust bundle.
+//
+// It takes the whole credential rather than a bare SPIFFE ID, so an authorizer
+// can read issuer-supplied claims, and so the signature stays transport neutral
+// and can gain fields without a breaking change.
+type Authorizer func(svid *witsvid.SVID) error
+
+// AuthorizeAny allows any authenticated peer.
+func AuthorizeAny() Authorizer {
+	return AdaptMatcher(spiffeid.MatchAny())
+}
+
+// AuthorizeID allows a specific SPIFFE ID.
+func AuthorizeID(allowed spiffeid.ID) Authorizer {
+	return AdaptMatcher(spiffeid.MatchID(allowed))
+}
+
+// AuthorizeOneOf allows any SPIFFE ID in the given list of IDs.
+func AuthorizeOneOf(allowed ...spiffeid.ID) Authorizer {
+	return AdaptMatcher(spiffeid.MatchOneOf(allowed...))
+}
+
+// AuthorizeMemberOf allows any SPIFFE ID in the given trust domain.
+func AuthorizeMemberOf(allowed spiffeid.TrustDomain) Authorizer {
+	return AdaptMatcher(spiffeid.MatchMemberOf(allowed))
+}
+
+// AdaptMatcher adapts any spiffeid.Matcher for use as an Authorizer, which
+// authorizes on the SPIFFE ID alone and ignores the rest of the credential.
+//
+// This is the same adaptation tlsconfig offers for the X.509 path, so a matcher
+// written for one works unchanged with the other.
+func AdaptMatcher(matcher spiffeid.Matcher) Authorizer {
+	return Authorizer(func(svid *witsvid.SVID) error {
+		if svid == nil {
+			return errors.New("no WIT-SVID to authorize")
+		}
+		return matcher(svid.ID)
+	})
+}

--- a/exp/witwpt/authorizer.go
+++ b/exp/witwpt/authorizer.go
@@ -7,13 +7,9 @@ import (
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 )
 
-// Authorizer decides whether an authenticated peer may proceed. It runs after
-// verification has succeeded, so the SVID it receives is one whose proof of
-// possession was checked against the trust bundle.
-//
-// It takes the whole credential rather than a bare SPIFFE ID, so an authorizer
-// can read issuer-supplied claims, and so the signature stays transport neutral
-// and can gain fields without a breaking change.
+// Authorizer decides whether an authenticated peer may proceed. It runs only
+// after verification has succeeded, and takes the whole credential rather than a
+// bare SPIFFE ID so it can also read issuer-supplied claims.
 type Authorizer func(svid *witsvid.SVID) error
 
 // AuthorizeAny allows any authenticated peer.
@@ -36,11 +32,8 @@ func AuthorizeMemberOf(allowed spiffeid.TrustDomain) Authorizer {
 	return AdaptMatcher(spiffeid.MatchMemberOf(allowed))
 }
 
-// AdaptMatcher adapts any spiffeid.Matcher for use as an Authorizer, which
-// authorizes on the SPIFFE ID alone and ignores the rest of the credential.
-//
-// This is the same adaptation tlsconfig offers for the X.509 path, so a matcher
-// written for one works unchanged with the other.
+// AdaptMatcher adapts any spiffeid.Matcher for use as an Authorizer which only
+// authorizes the SPIFFE ID but otherwise ignores the credential.
 func AdaptMatcher(matcher spiffeid.Matcher) Authorizer {
 	return Authorizer(func(svid *witsvid.SVID) error {
 		if svid == nil {

--- a/exp/witwpt/authorizer_test.go
+++ b/exp/witwpt/authorizer_test.go
@@ -1,0 +1,106 @@
+package witwpt_test
+
+import (
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/exp/svid/witsvid"
+	"github.com/spiffe/go-spiffe/v2/exp/witwpt"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthorizers(t *testing.T) {
+	var (
+		exampleTD = spiffeid.RequireTrustDomainFromString("example.org")
+		otherTD   = spiffeid.RequireTrustDomainFromString("other.org")
+		client    = spiffeid.RequireFromPath(exampleTD, "/client")
+		server    = spiffeid.RequireFromPath(exampleTD, "/server")
+		stranger  = spiffeid.RequireFromPath(otherTD, "/client")
+	)
+
+	tests := []struct {
+		name       string
+		authorizer witwpt.Authorizer
+		id         spiffeid.ID
+		err        string
+	}{
+		{name: "any allows anyone", authorizer: witwpt.AuthorizeAny(), id: stranger},
+		{name: "id allows the match", authorizer: witwpt.AuthorizeID(client), id: client},
+		{
+			name:       "id rejects another id",
+			authorizer: witwpt.AuthorizeID(client),
+			id:         server,
+			err:        `unexpected ID "spiffe://example.org/server"`,
+		},
+		{
+			name:       "one of allows a listed id",
+			authorizer: witwpt.AuthorizeOneOf(client, server),
+			id:         server,
+		},
+		{
+			name:       "one of rejects an unlisted id",
+			authorizer: witwpt.AuthorizeOneOf(client, server),
+			id:         stranger,
+			err:        `unexpected ID "spiffe://other.org/client"`,
+		},
+		{
+			name:       "member of allows the trust domain",
+			authorizer: witwpt.AuthorizeMemberOf(exampleTD),
+			id:         client,
+		},
+		{
+			name:       "member of rejects another trust domain",
+			authorizer: witwpt.AuthorizeMemberOf(exampleTD),
+			id:         stranger,
+			err:        `unexpected trust domain "other.org"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.authorizer(&witsvid.SVID{ID: tt.id})
+			if tt.err != "" {
+				require.EqualError(t, err, tt.err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestAuthorizerReceivesTheWholeCredential(t *testing.T) {
+	// Passing the SVID rather than a bare ID is what lets an authorizer read
+	// issuer-supplied claims, which tlsconfig.Authorizer cannot do.
+	svid := &witsvid.SVID{
+		ID:     spiffeid.RequireFromString("spiffe://example.org/client"),
+		Claims: map[string]interface{}{"groups": []any{"admin"}},
+	}
+
+	var seen *witsvid.SVID
+	authorizer := witwpt.Authorizer(func(s *witsvid.SVID) error {
+		seen = s
+		return nil
+	})
+
+	require.NoError(t, authorizer(svid))
+	require.Same(t, svid, seen)
+	assert.Equal(t, []any{"admin"}, seen.Claims["groups"])
+}
+
+func TestAdaptMatcher(t *testing.T) {
+	client := spiffeid.RequireFromString("spiffe://example.org/client")
+
+	authorizer := witwpt.AdaptMatcher(spiffeid.MatchID(client))
+	require.NoError(t, authorizer(&witsvid.SVID{ID: client}))
+
+	err := authorizer(&witsvid.SVID{ID: spiffeid.RequireFromString("spiffe://example.org/other")})
+	require.EqualError(t, err, `unexpected ID "spiffe://example.org/other"`)
+}
+
+func TestAuthorizersRejectNilCredential(t *testing.T) {
+	// A nil SVID means verification did not actually produce one; the built-in
+	// authorizers must refuse rather than dereference it.
+	require.Error(t, witwpt.AuthorizeAny()(nil))
+	require.Error(t, witwpt.AuthorizeID(spiffeid.RequireFromString("spiffe://example.org/a"))(nil))
+}

--- a/exp/witwpt/errors.go
+++ b/exp/witwpt/errors.go
@@ -1,0 +1,81 @@
+package witwpt
+
+import (
+	"errors"
+	"fmt"
+)
+
+// errReplayed is the cause reported when a proof's jti has already been
+// recorded. It is unexported deliberately: callers distinguish failures by
+// Stage, which is stable, rather than by matching sentinel values.
+var errReplayed = errors.New("proof token has already been used")
+
+// Stage identifies which step of verification rejected a request. It is
+// machine-readable so a rejection can be counted, not only logged.
+type Stage int
+
+const (
+	// StageWIT covers validating the WIT-SVID against the trust bundle: its
+	// typ, kid, signature, expiry, subject, and confirmation key. An unfederated
+	// trust domain and an unknown key ID both land here, because witsvid
+	// reports them through one call whose wrapped error carries the detail.
+	StageWIT Stage = iota + 1
+
+	// StageProof covers verifying the WPT against the confirmation key the
+	// WIT-SVID named, including its binding to that credential and to the target.
+	StageProof
+
+	// StageReplay covers a proof whose jti has already been recorded.
+	StageReplay
+)
+
+// String returns a short, stable label suitable for use as a metric dimension.
+func (s Stage) String() string {
+	switch s {
+	case StageWIT:
+		return "wit"
+	case StageProof:
+		return "proof"
+	case StageReplay:
+		return "replay"
+	default:
+		return "unknown"
+	}
+}
+
+// Error is a verification failure together with the stage that produced it.
+//
+// Verify returns errors of this type so an operator's error handler can count
+// rejections by stage while the caller is told only that it was refused. This is
+// a deliberate exception to the surrounding convention of opaque wrapped errors:
+// Verify is the one place where the caller-facing message is intentionally
+// uninformative, so it is the one place a typed error earns its keep.
+type Error struct {
+	// Stage is the step that rejected the request.
+	Stage Stage
+
+	// Err is the underlying cause.
+	Err error
+}
+
+func (e *Error) Error() string {
+	var what string
+	switch e.Stage {
+	case StageWIT:
+		what = "WIT-SVID validation failed"
+	case StageProof:
+		what = "proof verification failed"
+	case StageReplay:
+		what = "replay check failed"
+	default:
+		what = "verification failed"
+	}
+	return fmt.Sprintf("witwpt: %s: %v", what, e.Err)
+}
+
+func (e *Error) Unwrap() error { return e.Err }
+
+// newError builds a staged verification error.
+func newError(stage Stage, err error) error {
+	return &Error{Stage: stage, Err: err}
+}

--- a/exp/witwpt/errors.go
+++ b/exp/witwpt/errors.go
@@ -6,19 +6,16 @@ import (
 )
 
 // errReplayed is the cause reported when a proof's jti has already been
-// recorded. It is unexported deliberately: callers distinguish failures by
-// Stage, which is stable, rather than by matching sentinel values.
+// recorded. It is unexported because callers distinguish failures by Stage.
 var errReplayed = errors.New("proof token has already been used")
 
-// Stage identifies which step of verification rejected a request. It is
-// machine-readable so a rejection can be counted, not only logged.
+// Stage identifies which step of verification rejected a request, so a
+// rejection can be counted and not only logged.
 type Stage int
 
 const (
-	// StageWIT covers validating the WIT-SVID against the trust bundle: its
-	// typ, kid, signature, expiry, subject, and confirmation key. An unfederated
-	// trust domain and an unknown key ID both land here, because witsvid
-	// reports them through one call whose wrapped error carries the detail.
+	// StageWIT covers validating the WIT-SVID against the trust bundle: its typ,
+	// kid, signature, expiry, subject, and confirmation key.
 	StageWIT Stage = iota + 1
 
 	// StageProof covers verifying the WPT against the confirmation key the
@@ -44,12 +41,8 @@ func (s Stage) String() string {
 }
 
 // Error is a verification failure together with the stage that produced it.
-//
-// Verify returns errors of this type so an operator's error handler can count
-// rejections by stage while the caller is told only that it was refused. This is
-// a deliberate exception to the surrounding convention of opaque wrapped errors:
-// Verify is the one place where the caller-facing message is intentionally
-// uninformative, so it is the one place a typed error earns its keep.
+// Verify returns errors of this type so an error handler can count rejections
+// by stage while the remote caller is told only that it was refused.
 type Error struct {
 	// Stage is the step that rejected the request.
 	Stage Stage

--- a/exp/witwpt/errors_test.go
+++ b/exp/witwpt/errors_test.go
@@ -1,0 +1,40 @@
+package witwpt_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/exp/witwpt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStageString(t *testing.T) {
+	// Stage names are used as metric labels, so they are part of the API.
+	assert.Equal(t, "wit", witwpt.StageWIT.String())
+	assert.Equal(t, "proof", witwpt.StageProof.String())
+	assert.Equal(t, "replay", witwpt.StageReplay.String())
+	assert.Equal(t, "unknown", witwpt.Stage(0).String())
+}
+
+func TestErrorCarriesStageAndUnwraps(t *testing.T) {
+	cause := errors.New("boom")
+	err := &witwpt.Error{Stage: witwpt.StageProof, Err: cause}
+
+	t.Run("message names the stage and the cause", func(t *testing.T) {
+		assert.EqualError(t, err, "witwpt: proof verification failed: boom")
+	})
+
+	t.Run("unwraps to the cause", func(t *testing.T) {
+		assert.ErrorIs(t, err, cause)
+	})
+
+	t.Run("errors.As recovers the stage through wrapping", func(t *testing.T) {
+		wrapped := fmt.Errorf("middleware: %w", err)
+
+		var got *witwpt.Error
+		require.ErrorAs(t, wrapped, &got)
+		assert.Equal(t, witwpt.StageProof, got.Stage)
+	})
+}

--- a/exp/witwpt/mint.go
+++ b/exp/witwpt/mint.go
@@ -1,15 +1,11 @@
 // Package witwpt implements the Workload Proof Token (WPT) proof-of-possession
-// protocol for WIT-SVIDs, as specified by draft-ietf-wimse-wpt-01.
-//
-// A WIT-SVID carries an identity and names a confirmation key in its cnf.jwk
-// claim; it is never a bearer token. To present one, a workload mints a short
-// lived WPT signed with the matching private key, binding the proof to both the
-// credential (via wth) and the request target (via aud). A verifier validates
-// the WIT-SVID against its trust bundle first, and only then checks the proof
-// against the confirmation key the credential named.
+// protocol for WIT-SVIDs, as specified by draft-ietf-wimse-wpt-01. A workload
+// mints a short-lived WPT signed with the private key matching the WIT-SVID's
+// cnf.jwk claim, binding the proof to the credential (wth) and to the request
+// target (aud).
 //
 // This package is transport neutral. See exp/withttp for the net/http
-// integration, which is what most callers should use.
+// integration.
 package witwpt
 
 import (
@@ -27,28 +23,24 @@ import (
 
 const (
 	// DefaultProofLifetime is how far ahead a minted proof's exp is set. The
-	// draft calls for "minutes or seconds"; a fresh proof is minted per request,
-	// so this is a ceiling on replay, not a cache duration.
+	// draft calls for a lifetime of "minutes or seconds".
 	DefaultProofLifetime = 60 * time.Second
 
 	// DefaultLeeway is the clock-skew tolerance a verifier applies to a proof's
-	// exp and nbf. It is deliberately far tighter than the one-minute
-	// jwt.DefaultLeeway that witsvid applies to the WIT: reusing that here would
-	// roughly double a 60-second proof's effective validity.
+	// exp and nbf. It is tighter than the one-minute jwt.DefaultLeeway witsvid
+	// applies to the WIT, which would nearly double a proof's validity.
 	DefaultLeeway = 10 * time.Second
 
-	// DefaultMaxLifetime is the furthest-future exp a verifier will accept. It
-	// gives teeth to wpt-01 §2's requirement that "unreasonably far future"
-	// values SHOULD be rejected; without it a client could mint a proof valid
-	// for a week and nothing would object.
+	// DefaultMaxLifetime is the furthest-future exp a verifier accepts,
+	// enforcing wpt-01 §2's rejection of "unreasonably far future" values.
 	DefaultMaxLifetime = 5 * time.Minute
 )
 
 // proofType is the required typ header of a WPT (wpt-01 §2).
 const proofType = "wpt+jwt"
 
-// jtiBytes is the entropy behind each proof's jti. wpt-01 §2 asks for a
-// collision probability that is "negligible", suggesting 128 random bits.
+// jtiBytes is the entropy behind each proof's jti, per wpt-01 §2's suggested
+// 128 random bits.
 const jtiBytes = 16
 
 // MintOption configures Mint.
@@ -65,22 +57,19 @@ type mintOption func(*mintConfig)
 func (fn mintOption) configureMint(c *mintConfig) { fn(c) }
 
 // WithProofLifetime sets how far ahead the minted proof's exp is placed,
-// overriding DefaultProofLifetime. A verifier rejects a lifetime beyond its own
-// maximum, so raising this past DefaultMaxLifetime will cause rejections.
+// overriding DefaultProofLifetime. Raising it past the verifier's maximum
+// lifetime causes the proof to be rejected.
 func WithProofLifetime(lifetime time.Duration) MintOption {
 	return mintOption(func(c *mintConfig) {
 		c.lifetime = lifetime
 	})
 }
 
-// Mint returns a Workload Proof Token proving possession of svid's confirmation
-// key, bound to svid and scoped to audience.
+// Mint returns a Workload Proof Token, in JWS compact serialization, proving
+// possession of svid's confirmation key, bound to svid and scoped to audience.
 //
 // audience should be the request target URI without query or fragment
-// (wpt-01 §2); a verifier compares it under normalization, so a full target URI
-// is both correct and portable. A fresh proof should be minted per request.
-//
-// The returned token is a compact JWS and is safe to place in an ASCII header.
+// (wpt-01 §2). A fresh proof should be minted per request.
 func Mint(svid *witsvid.SVID, audience string, opts ...MintOption) (string, error) {
 	if svid == nil {
 		return "", wrapErr(errors.New("no WIT-SVID provided"))
@@ -97,8 +86,7 @@ func Mint(svid *witsvid.SVID, audience string, opts ...MintOption) (string, erro
 		return "", wrapErr(errors.New("WIT-SVID has no token to bind the proof to"))
 	}
 
-	// wpt-01 §2 requires the proof's alg to string-equal the WIT's cnf.jwk.alg,
-	// so it is read from the credential rather than chosen here.
+	// wpt-01 §2 requires the proof's alg to string-equal the WIT's cnf.jwk.alg.
 	alg, err := confirmationAlgorithm(svid)
 	if err != nil {
 		return "", err
@@ -138,19 +126,15 @@ func Mint(svid *witsvid.SVID, audience string, opts ...MintOption) (string, erro
 
 // WITThumbprint returns the wth claim value binding a proof to a WIT-SVID:
 // base64url(SHA-256(ASCII(token))) over the compact serialization, per
-// wpt-01 §2.
-//
-// Note this hashes the token string itself. It is NOT an RFC 7638 JWK
-// thumbprint of the confirmation key, which is a distinct and incompatible
-// construction that would nonetheless interoperate with itself.
+// wpt-01 §2. This hashes the token itself, not an RFC 7638 JWK thumbprint of
+// the confirmation key.
 func WITThumbprint(witToken string) string {
 	sum := sha256.Sum256([]byte(witToken))
 	return base64.RawURLEncoding.EncodeToString(sum[:])
 }
 
 // confirmationAlgorithm reads cnf.jwk.alg from the credential's claims. witsvid
-// already validated that the value is present, a string, and a supported
-// asymmetric algorithm.
+// already validated it is present and a supported asymmetric algorithm.
 func confirmationAlgorithm(svid *witsvid.SVID) (jose.SignatureAlgorithm, error) {
 	cnf, ok := svid.Claims["cnf"].(map[string]any)
 	if !ok {

--- a/exp/witwpt/mint.go
+++ b/exp/witwpt/mint.go
@@ -1,0 +1,176 @@
+// Package witwpt implements the Workload Proof Token (WPT) proof-of-possession
+// protocol for WIT-SVIDs, as specified by draft-ietf-wimse-wpt-01.
+//
+// A WIT-SVID carries an identity and names a confirmation key in its cnf.jwk
+// claim; it is never a bearer token. To present one, a workload mints a short
+// lived WPT signed with the matching private key, binding the proof to both the
+// credential (via wth) and the request target (via aud). A verifier validates
+// the WIT-SVID against its trust bundle first, and only then checks the proof
+// against the confirmation key the credential named.
+//
+// This package is transport neutral. See exp/withttp for the net/http
+// integration, which is what most callers should use.
+package witwpt
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/spiffe/go-spiffe/v2/exp/svid/witsvid"
+)
+
+const (
+	// DefaultProofLifetime is how far ahead a minted proof's exp is set. The
+	// draft calls for "minutes or seconds"; a fresh proof is minted per request,
+	// so this is a ceiling on replay, not a cache duration.
+	DefaultProofLifetime = 60 * time.Second
+
+	// DefaultLeeway is the clock-skew tolerance a verifier applies to a proof's
+	// exp and nbf. It is deliberately far tighter than the one-minute
+	// jwt.DefaultLeeway that witsvid applies to the WIT: reusing that here would
+	// roughly double a 60-second proof's effective validity.
+	DefaultLeeway = 10 * time.Second
+
+	// DefaultMaxLifetime is the furthest-future exp a verifier will accept. It
+	// gives teeth to wpt-01 §2's requirement that "unreasonably far future"
+	// values SHOULD be rejected; without it a client could mint a proof valid
+	// for a week and nothing would object.
+	DefaultMaxLifetime = 5 * time.Minute
+)
+
+// proofType is the required typ header of a WPT (wpt-01 §2).
+const proofType = "wpt+jwt"
+
+// jtiBytes is the entropy behind each proof's jti. wpt-01 §2 asks for a
+// collision probability that is "negligible", suggesting 128 random bits.
+const jtiBytes = 16
+
+// MintOption configures Mint.
+type MintOption interface {
+	configureMint(*mintConfig)
+}
+
+type mintConfig struct {
+	lifetime time.Duration
+}
+
+type mintOption func(*mintConfig)
+
+func (fn mintOption) configureMint(c *mintConfig) { fn(c) }
+
+// WithProofLifetime sets how far ahead the minted proof's exp is placed,
+// overriding DefaultProofLifetime. A verifier rejects a lifetime beyond its own
+// maximum, so raising this past DefaultMaxLifetime will cause rejections.
+func WithProofLifetime(lifetime time.Duration) MintOption {
+	return mintOption(func(c *mintConfig) {
+		c.lifetime = lifetime
+	})
+}
+
+// Mint returns a Workload Proof Token proving possession of svid's confirmation
+// key, bound to svid and scoped to audience.
+//
+// audience should be the request target URI without query or fragment
+// (wpt-01 §2); a verifier compares it under normalization, so a full target URI
+// is both correct and portable. A fresh proof should be minted per request.
+//
+// The returned token is a compact JWS and is safe to place in an ASCII header.
+func Mint(svid *witsvid.SVID, audience string, opts ...MintOption) (string, error) {
+	if svid == nil {
+		return "", wrapErr(errors.New("no WIT-SVID provided"))
+	}
+	if audience == "" {
+		return "", wrapErr(errors.New("no audience provided"))
+	}
+	if svid.PrivateKey == nil {
+		return "", wrapErr(errors.New("WIT-SVID has no private key, so possession cannot be proven"))
+	}
+
+	witToken := svid.Marshal()
+	if witToken == "" {
+		return "", wrapErr(errors.New("WIT-SVID has no token to bind the proof to"))
+	}
+
+	// wpt-01 §2 requires the proof's alg to string-equal the WIT's cnf.jwk.alg,
+	// so it is read from the credential rather than chosen here.
+	alg, err := confirmationAlgorithm(svid)
+	if err != nil {
+		return "", err
+	}
+
+	config := &mintConfig{lifetime: DefaultProofLifetime}
+	for _, opt := range opts {
+		opt.configureMint(config)
+	}
+
+	jti, err := newJTI()
+	if err != nil {
+		return "", err
+	}
+
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: alg, Key: svid.PrivateKey},
+		(&jose.SignerOptions{}).WithType(proofType),
+	)
+	if err != nil {
+		return "", wrapErr(fmt.Errorf("unable to build proof signer: %w", err))
+	}
+
+	now := time.Now()
+	proof, err := jwt.Signed(signer).Claims(map[string]any{
+		"aud": audience,
+		"exp": jwt.NewNumericDate(now.Add(config.lifetime)),
+		"iat": jwt.NewNumericDate(now),
+		"jti": jti,
+		"wth": WITThumbprint(witToken),
+	}).Serialize()
+	if err != nil {
+		return "", wrapErr(fmt.Errorf("unable to sign proof: %w", err))
+	}
+	return proof, nil
+}
+
+// WITThumbprint returns the wth claim value binding a proof to a WIT-SVID:
+// base64url(SHA-256(ASCII(token))) over the compact serialization, per
+// wpt-01 §2.
+//
+// Note this hashes the token string itself. It is NOT an RFC 7638 JWK
+// thumbprint of the confirmation key, which is a distinct and incompatible
+// construction that would nonetheless interoperate with itself.
+func WITThumbprint(witToken string) string {
+	sum := sha256.Sum256([]byte(witToken))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+// confirmationAlgorithm reads cnf.jwk.alg from the credential's claims. witsvid
+// already validated that the value is present, a string, and a supported
+// asymmetric algorithm.
+func confirmationAlgorithm(svid *witsvid.SVID) (jose.SignatureAlgorithm, error) {
+	cnf, ok := svid.Claims["cnf"].(map[string]any)
+	if !ok {
+		return "", wrapErr(errors.New("WIT-SVID claims have no cnf object"))
+	}
+	jwk, ok := cnf["jwk"].(map[string]any)
+	if !ok {
+		return "", wrapErr(errors.New("WIT-SVID cnf claim has no jwk object"))
+	}
+	alg, ok := jwk["alg"].(string)
+	if !ok || alg == "" {
+		return "", wrapErr(errors.New("WIT-SVID cnf.jwk has no alg"))
+	}
+	return jose.SignatureAlgorithm(alg), nil
+}
+
+func newJTI() (string, error) {
+	raw := make([]byte, jtiBytes)
+	if _, err := rand.Read(raw); err != nil {
+		return "", wrapErr(fmt.Errorf("unable to generate proof id: %w", err))
+	}
+	return base64.RawURLEncoding.EncodeToString(raw), nil
+}

--- a/exp/witwpt/mint_test.go
+++ b/exp/witwpt/mint_test.go
@@ -1,0 +1,281 @@
+package witwpt_test
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/spiffe/go-spiffe/v2/exp/svid/witsvid"
+	"github.com/spiffe/go-spiffe/v2/exp/witwpt"
+	"github.com/spiffe/go-spiffe/v2/internal/test"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// witFixture is a committed WIT-SVID whose exp is 2100-01-01, so it does not
+// rot. Its signature is a fixed 64-byte filler: ParseInsecure does not verify
+// signatures, and holding the token bytes constant is what makes wantWTH below
+// a stable, independently checkable value.
+const witFixture = "eyJhbGciOiJFUzI1NiIsImtpZCI6IndpdC1hdXRob3JpdHktMSIsInR5cCI6IndpdCtqd3QifQ." +
+	"eyJjbmYiOnsiandrIjp7ImFsZyI6IkVTMjU2IiwiY3J2IjoiUC0yNTYiLCJraWQiOiJjbmYtMSIsImt0eSI6IkVDIiwi" +
+	"eCI6ImlLWnM3QzlPTWFrWm9DTkZDSmpjSWU4aHB4QkR2SGVDSTJsdzVnRVR1dWsiLCJ5IjoieHkzMGFfYzJ3YmduMkxl" +
+	"SV9od28xRVR3S2tzb0szemlTZGVyM2loOTR3OCJ9fSwiZXhwIjo0MTAyNDQ0ODAwLCJpYXQiOjE3NTAwMDAwMDAsImlz" +
+	"cyI6InNwaWZmZTovL2V4YW1wbGUub3JnIiwic3ViIjoic3BpZmZlOi8vZXhhbXBsZS5vcmcvY2xpZW50In0." +
+	"AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0-Pw"
+
+// witFixturePrivJWK is the private half of witFixture's cnf.jwk. It is a test
+// fixture, not a credential.
+const witFixturePrivJWK = `{"kty":"EC","kid":"cnf-1","crv":"P-256","alg":"ES256",` +
+	`"x":"iKZs7C9OMakZoCNFCJjcIe8hpxBDvHeCI2lw5gETuuk",` +
+	`"y":"xy30a_c2wbgn2LeI_hwo1ETwKksoK3ziSder3ih94w8",` +
+	`"d":"i7Q5Wgfd1jPpqMlApObMNHhkyTSEnVVLKtLfIOizFPE"}`
+
+// wantWTH is base64url(SHA-256(ASCII(witFixture))) per draft-ietf-wimse-wpt-01
+// §2 -- a hash of the whole compact serialization, NOT an RFC 7638 JWK
+// thumbprint. Derived without this package's code, and reproducible with:
+//
+//	printf '%s' "$WIT" | openssl dgst -sha256 -binary | base64 | tr '+/' '-_' | tr -d '='
+const wantWTH = "YbWmBlkKlYIC8qAmT-RLp-ZWyPIfrijSxszwpN3CUyQ"
+
+const testAudience = "https://server.example.org/v2/orders"
+
+// TestMintWTHMatchesIndependentlyDerivedConstant is the anchor test for the
+// single highest-risk value in the implementation: the wrong reading of wth
+// (a JWK thumbprint) would still round-trip against our own verifier.
+func TestMintWTHMatchesIndependentlyDerivedConstant(t *testing.T) {
+	svid := fixtureSVID(t)
+
+	proof, err := witwpt.Mint(svid, testAudience)
+	require.NoError(t, err)
+
+	claims := parseProofClaims(t, proof, svid.PublicKey)
+	assert.Equal(t, wantWTH, claims["wth"],
+		"wth must be base64url(SHA-256(WIT compact serialization))")
+
+	// Guard against the tempting-but-wrong RFC 7638 thumbprint reading.
+	thumbprint, err := (&jose.JSONWebKey{Key: svid.PublicKey}).Thumbprint(crypto.SHA256)
+	require.NoError(t, err)
+	assert.NotEqual(t, base64.RawURLEncoding.EncodeToString(thumbprint), claims["wth"],
+		"wth must not be the JWK thumbprint")
+}
+
+func TestMintClaimAndHeaderShape(t *testing.T) {
+	svid := fixtureSVID(t)
+
+	before := time.Now()
+	proof, err := witwpt.Mint(svid, testAudience)
+	require.NoError(t, err)
+
+	tok, err := jwt.ParseSigned(proof, allProofAlgorithms)
+	require.NoError(t, err)
+
+	t.Run("typ header is wpt+jwt", func(t *testing.T) {
+		assert.Equal(t, "wpt+jwt", tok.Headers[0].ExtraHeaders[jose.HeaderType])
+	})
+
+	claims := parseProofClaims(t, proof, svid.PublicKey)
+
+	t.Run("aud is the full target URI, query and fragment aside", func(t *testing.T) {
+		assert.Equal(t, testAudience, claims["aud"])
+	})
+
+	t.Run("exp defaults to DefaultProofLifetime ahead", func(t *testing.T) {
+		exp := numericDate(t, claims["exp"])
+		assert.WithinDuration(t, before.Add(witwpt.DefaultProofLifetime), exp, 5*time.Second)
+	})
+
+	t.Run("jti is present", func(t *testing.T) {
+		assert.NotEmpty(t, claims["jti"])
+	})
+
+	t.Run("no aud-free or identity claims are invented", func(t *testing.T) {
+		// The WPT carries no identity; sub must not appear.
+		assert.NotContains(t, claims, "sub")
+	})
+}
+
+func TestMintAlgTracksCnfJWKAlg(t *testing.T) {
+	// wpt-01 §2 requires the proof's alg to string-equal the WIT's cnf.jwk.alg,
+	// so it is read from the credential rather than chosen by us.
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	ecKey := test.NewEC256Key(t)
+
+	tests := []struct {
+		alg jose.SignatureAlgorithm
+		key crypto.Signer
+	}{
+		{alg: jose.ES256, key: ecKey},
+		{alg: jose.RS256, key: rsaKey},
+		{alg: jose.PS256, key: rsaKey},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.alg), func(t *testing.T) {
+			svid := makeWITSVID(t, tt.alg, tt.key)
+
+			proof, err := witwpt.Mint(svid, testAudience)
+			require.NoError(t, err)
+
+			tok, err := jwt.ParseSigned(proof, allProofAlgorithms)
+			require.NoError(t, err)
+			assert.Equal(t, string(tt.alg), tok.Headers[0].Algorithm)
+
+			// And the signature really verifies under the cnf public key.
+			var claims map[string]any
+			require.NoError(t, tok.Claims(tt.key.Public(), &claims))
+		})
+	}
+}
+
+func TestMintJTIIsUniqueAndAtLeast128Bits(t *testing.T) {
+	svid := fixtureSVID(t)
+
+	seen := make(map[string]struct{})
+	for range 50 {
+		proof, err := witwpt.Mint(svid, testAudience)
+		require.NoError(t, err)
+
+		jti, ok := parseProofClaims(t, proof, svid.PublicKey)["jti"].(string)
+		require.True(t, ok, "jti must be a string")
+
+		raw, err := base64.RawURLEncoding.DecodeString(jti)
+		require.NoError(t, err, "jti should be base64url")
+		assert.GreaterOrEqual(t, len(raw)*8, 128, "jti must carry at least 128 bits of entropy")
+
+		_, duplicate := seen[jti]
+		require.False(t, duplicate, "jti must not repeat")
+		seen[jti] = struct{}{}
+	}
+}
+
+func TestMintWithProofLifetime(t *testing.T) {
+	svid := fixtureSVID(t)
+
+	before := time.Now()
+	proof, err := witwpt.Mint(svid, testAudience, witwpt.WithProofLifetime(5*time.Second))
+	require.NoError(t, err)
+
+	exp := numericDate(t, parseProofClaims(t, proof, svid.PublicKey)["exp"])
+	assert.WithinDuration(t, before.Add(5*time.Second), exp, 2*time.Second)
+}
+
+func TestMintErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		svid func(*testing.T) *witsvid.SVID
+		aud  string
+		err  string
+	}{
+		{
+			name: "nil SVID",
+			svid: func(*testing.T) *witsvid.SVID { return nil },
+			aud:  testAudience,
+			err:  "witwpt: no WIT-SVID provided",
+		},
+		{
+			name: "SVID without a private key cannot prove possession",
+			svid: func(t *testing.T) *witsvid.SVID {
+				svid := fixtureSVID(t)
+				svid.PrivateKey = nil
+				return svid
+			},
+			aud: testAudience,
+			err: "witwpt: WIT-SVID has no private key, so possession cannot be proven",
+		},
+		{
+			name: "empty audience",
+			svid: fixtureSVID,
+			aud:  "",
+			err:  "witwpt: no audience provided",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proof, err := witwpt.Mint(tt.svid(t), tt.aud)
+			require.EqualError(t, err, tt.err)
+			assert.Empty(t, proof)
+		})
+	}
+}
+
+// --- helpers ---
+
+var allProofAlgorithms = []jose.SignatureAlgorithm{
+	jose.RS256, jose.RS384, jose.RS512,
+	jose.ES256, jose.ES384, jose.ES512,
+	jose.PS256, jose.PS384, jose.PS512,
+}
+
+// fixtureSVID parses witFixture and attaches its committed private key, giving
+// an SVID whose token bytes -- and therefore whose wth -- are constant.
+func fixtureSVID(t *testing.T) *witsvid.SVID {
+	t.Helper()
+	svid, err := witsvid.ParseInsecure(witFixture)
+	require.NoError(t, err)
+	require.Equal(t, witFixture, svid.Marshal())
+
+	var jwk jose.JSONWebKey
+	require.NoError(t, jwk.UnmarshalJSON([]byte(witFixturePrivJWK)))
+	svid.PrivateKey = jwk.Key
+	return svid
+}
+
+// makeWITSVID builds a WIT-SVID whose cnf.jwk.alg is alg and whose confirmation
+// key is key, for cases where the token bytes need not be fixed.
+func makeWITSVID(t *testing.T, alg jose.SignatureAlgorithm, key crypto.Signer) *witsvid.SVID {
+	t.Helper()
+
+	cnfJWK := jose.JSONWebKey{Key: key.Public(), KeyID: "cnf-1", Algorithm: string(alg)}
+	cnfBytes, err := cnfJWK.MarshalJSON()
+	require.NoError(t, err)
+	var cnfMap map[string]any
+	require.NoError(t, json.Unmarshal(cnfBytes, &cnfMap))
+
+	authority := test.NewEC256Key(t)
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.ES256, Key: jose.JSONWebKey{Key: authority, KeyID: "auth-1"}},
+		(&jose.SignerOptions{}).WithType("wit+jwt"),
+	)
+	require.NoError(t, err)
+
+	token, err := jwt.Signed(signer).Claims(map[string]any{
+		"sub": spiffeid.RequireFromString("spiffe://example.org/client").String(),
+		"exp": jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		"cnf": map[string]any{"jwk": cnfMap},
+	}).Serialize()
+	require.NoError(t, err)
+
+	svid, err := witsvid.ParseInsecure(token)
+	require.NoError(t, err)
+	svid.PrivateKey = key
+	return svid
+}
+
+// parseProofClaims parses a proof and verifies its signature under pub, then
+// returns its claims. It never routes through this package's Verify, so mint
+// coverage does not depend on verify being correct.
+func parseProofClaims(t *testing.T, proof string, pub crypto.PublicKey) map[string]any {
+	t.Helper()
+	tok, err := jwt.ParseSigned(proof, allProofAlgorithms)
+	require.NoError(t, err)
+
+	var claims map[string]any
+	require.NoError(t, tok.Claims(pub, &claims))
+	return claims
+}
+
+func numericDate(t *testing.T, raw any) time.Time {
+	t.Helper()
+	seconds, ok := raw.(float64)
+	require.True(t, ok, "expected a JSON number, got %T", raw)
+	return time.Unix(int64(seconds), 0)
+}

--- a/exp/witwpt/replaycache.go
+++ b/exp/witwpt/replaycache.go
@@ -15,32 +15,23 @@ const minSweepSize = 128
 // ReplayCache remembers which proofs have been seen, so a captured proof cannot
 // be presented twice within its lifetime. wpt-01 §2 RECOMMENDS this check.
 //
-// Note it is the WPT's jti that is recorded. A WIT-SVID's own jti MUST NOT be
-// used for replay protection (SPIFFE WIT-SVID.md §3.3), because the same value
-// may legitimately be issued to two instances on one host.
+// It is the WPT's jti that is recorded; a WIT-SVID's own jti MUST NOT be used
+// for replay protection (SPIFFE WIT-SVID.md §3.3).
 type ReplayCache interface {
 	// CheckAndRecord records the proof identified by id and jti, returning an
 	// error if that pair has already been recorded. exp is when the record may
-	// be dropped.
-	//
-	// Implementations MUST make the check and the record atomic. A two-step
-	// interface would let two verifiers both observe "unseen" and both accept.
+	// be dropped. Implementations MUST make the check and the record atomic.
 	CheckAndRecord(ctx context.Context, id spiffeid.ID, jti string, exp time.Time) error
 }
 
 // NewMemoryReplayCache returns a ReplayCache holding records in memory for the
-// life of the process.
+// life of the process, reclaiming expired records during writes so it owns no
+// goroutine and needs no Close.
 //
-// It protects a single process only. A deployment running several replicas
-// behind a load balancer needs a shared store to reject a proof replayed to a
-// different replica; implement ReplayCache over one (a Redis SET NX EX maps
-// onto CheckAndRecord directly) and pass it to WithReplayCache.
-//
-// The footprint is bounded by the verifier's maximum accepted proof lifetime,
-// since no record is worth keeping past it, and only peers that already cleared
-// WIT validation and proof verification ever reach the cache. Expired records
-// are reclaimed during writes, so the cache owns no goroutine and needs no
-// Close.
+// It covers a single process only. A deployment running several replicas needs a
+// shared store to reject a proof replayed to a different replica; implement
+// ReplayCache over one (a Redis SET NX EX maps onto CheckAndRecord) and pass it
+// to WithReplayCache.
 func NewMemoryReplayCache() ReplayCache {
 	return newMemoryReplayCache()
 }
@@ -78,8 +69,7 @@ func (c *memoryReplayCache) CheckAndRecord(
 
 	key := replayKey{id: id.String(), jti: jti}
 	if previous, ok := c.entries[key]; ok && previous.After(now) {
-		// Returned unprefixed so the caller that surfaces it -- normally Verify,
-		// wrapping it as StageReplay -- supplies the one package prefix.
+		// Unprefixed, since Verify wraps it as StageReplay with the package prefix.
 		return errReplayed
 	}
 
@@ -87,8 +77,7 @@ func (c *memoryReplayCache) CheckAndRecord(
 	return nil
 }
 
-// sweep drops every record whose exp has passed. The one mutex held across
-// check and insert satisfies the interface's atomicity requirement outright.
+// sweep drops every record whose exp has passed. The caller must hold the mutex.
 func (c *memoryReplayCache) sweep(now time.Time) {
 	for key, exp := range c.entries {
 		if !exp.After(now) {

--- a/exp/witwpt/replaycache.go
+++ b/exp/witwpt/replaycache.go
@@ -1,0 +1,98 @@
+package witwpt
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+)
+
+// minSweepSize is the floor on how many entries accumulate before the memory
+// cache reclaims expired ones, so a small cache does not sweep on every insert.
+const minSweepSize = 128
+
+// ReplayCache remembers which proofs have been seen, so a captured proof cannot
+// be presented twice within its lifetime. wpt-01 §2 RECOMMENDS this check.
+//
+// Note it is the WPT's jti that is recorded. A WIT-SVID's own jti MUST NOT be
+// used for replay protection (SPIFFE WIT-SVID.md §3.3), because the same value
+// may legitimately be issued to two instances on one host.
+type ReplayCache interface {
+	// CheckAndRecord records the proof identified by id and jti, returning an
+	// error if that pair has already been recorded. exp is when the record may
+	// be dropped.
+	//
+	// Implementations MUST make the check and the record atomic. A two-step
+	// interface would let two verifiers both observe "unseen" and both accept.
+	CheckAndRecord(ctx context.Context, id spiffeid.ID, jti string, exp time.Time) error
+}
+
+// NewMemoryReplayCache returns a ReplayCache holding records in memory for the
+// life of the process.
+//
+// It protects a single process only. A deployment running several replicas
+// behind a load balancer needs a shared store to reject a proof replayed to a
+// different replica; implement ReplayCache over one (a Redis SET NX EX maps
+// onto CheckAndRecord directly) and pass it to WithReplayCache.
+//
+// The footprint is bounded by the verifier's maximum accepted proof lifetime,
+// since no record is worth keeping past it, and only peers that already cleared
+// WIT validation and proof verification ever reach the cache. Expired records
+// are reclaimed during writes, so the cache owns no goroutine and needs no
+// Close.
+func NewMemoryReplayCache() ReplayCache {
+	return newMemoryReplayCache()
+}
+
+func newMemoryReplayCache() *memoryReplayCache {
+	return &memoryReplayCache{
+		entries:   make(map[replayKey]time.Time),
+		nextSweep: minSweepSize,
+	}
+}
+
+type replayKey struct {
+	id  string
+	jti string
+}
+
+type memoryReplayCache struct {
+	mu        sync.Mutex
+	entries   map[replayKey]time.Time
+	nextSweep int
+}
+
+func (c *memoryReplayCache) CheckAndRecord(
+	_ context.Context, id spiffeid.ID, jti string, exp time.Time,
+) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := time.Now()
+	if len(c.entries) >= c.nextSweep {
+		c.sweep(now)
+		// Amortized O(1) per insert, holding steady state near twice the live set.
+		c.nextSweep = 2*len(c.entries) + minSweepSize
+	}
+
+	key := replayKey{id: id.String(), jti: jti}
+	if previous, ok := c.entries[key]; ok && previous.After(now) {
+		// Returned unprefixed so the caller that surfaces it -- normally Verify,
+		// wrapping it as StageReplay -- supplies the one package prefix.
+		return errReplayed
+	}
+
+	c.entries[key] = exp
+	return nil
+}
+
+// sweep drops every record whose exp has passed. The one mutex held across
+// check and insert satisfies the interface's atomicity requirement outright.
+func (c *memoryReplayCache) sweep(now time.Time) {
+	for key, exp := range c.entries {
+		if !exp.After(now) {
+			delete(c.entries, key)
+		}
+	}
+}

--- a/exp/witwpt/replaycache_internal_test.go
+++ b/exp/witwpt/replaycache_internal_test.go
@@ -1,0 +1,52 @@
+package witwpt
+
+// White-box, because the memory cache's bounded footprint is a design claim
+// about its internals: entries are reclaimed on write rather than by a sweeper
+// goroutine, which is what keeps NewMemoryReplayCache lifecycle-free. Nothing
+// observable from outside the package would show the map shrinking.
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemoryReplayCacheReclaimsOnWrite(t *testing.T) {
+	id := spiffeid.RequireFromString("spiffe://example.org/client")
+	cache := newMemoryReplayCache()
+	past := time.Now().Add(-time.Second)
+
+	// Insert well past the initial sweep threshold, all already expired.
+	for i := range 4 * minSweepSize {
+		jti := "expired-" + strconv.Itoa(i)
+		require.NoError(t, cache.CheckAndRecord(t.Context(), id, jti, past))
+	}
+
+	cache.mu.Lock()
+	got := len(cache.entries)
+	cache.mu.Unlock()
+
+	assert.LessOrEqual(t, got, 2*minSweepSize,
+		"expired entries must be reclaimed rather than accumulating")
+}
+
+func TestMemoryReplayCacheKeepsLiveEntriesWhileSweeping(t *testing.T) {
+	id := spiffeid.RequireFromString("spiffe://example.org/client")
+	cache := newMemoryReplayCache()
+	past := time.Now().Add(-time.Second)
+	future := time.Now().Add(time.Minute)
+
+	// One live entry, then enough expired ones to trigger sweeps.
+	require.NoError(t, cache.CheckAndRecord(t.Context(), id, "live", future))
+	for i := range 4 * minSweepSize {
+		require.NoError(t, cache.CheckAndRecord(t.Context(), id, "expired-"+strconv.Itoa(i), past))
+	}
+
+	// A sweep must not have dropped the still-valid record.
+	err := cache.CheckAndRecord(t.Context(), id, "live", future)
+	require.EqualError(t, err, "proof token has already been used")
+}

--- a/exp/witwpt/replaycache_test.go
+++ b/exp/witwpt/replaycache_test.go
@@ -1,0 +1,83 @@
+package witwpt_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/spiffe/go-spiffe/v2/exp/witwpt"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	replayClient = spiffeid.RequireFromString("spiffe://example.org/client")
+	replayOther  = spiffeid.RequireFromString("spiffe://example.org/other")
+)
+
+func TestMemoryReplayCache(t *testing.T) {
+	future := time.Now().Add(time.Minute)
+
+	t.Run("first use is recorded and accepted", func(t *testing.T) {
+		cache := witwpt.NewMemoryReplayCache()
+		require.NoError(t, cache.CheckAndRecord(t.Context(), replayClient, "jti-1", future))
+	})
+
+	t.Run("second use of the same jti is rejected", func(t *testing.T) {
+		cache := witwpt.NewMemoryReplayCache()
+		require.NoError(t, cache.CheckAndRecord(t.Context(), replayClient, "jti-1", future))
+
+		err := cache.CheckAndRecord(t.Context(), replayClient, "jti-1", future)
+		require.EqualError(t, err, "proof token has already been used")
+	})
+
+	t.Run("the same jti from a different identity is accepted", func(t *testing.T) {
+		// Keying on identity as well as jti means a workload minting a constant
+		// jti cannot consume shared key space and start rejecting other
+		// workloads' legitimate proofs.
+		cache := witwpt.NewMemoryReplayCache()
+		require.NoError(t, cache.CheckAndRecord(t.Context(), replayClient, "jti-1", future))
+		require.NoError(t, cache.CheckAndRecord(t.Context(), replayOther, "jti-1", future))
+	})
+
+	t.Run("an expired record no longer binds", func(t *testing.T) {
+		// exp tells the store when the record stops mattering, so no retention
+		// policy has to be configured.
+		cache := witwpt.NewMemoryReplayCache()
+		past := time.Now().Add(-time.Minute)
+		require.NoError(t, cache.CheckAndRecord(t.Context(), replayClient, "jti-1", past))
+		require.NoError(t, cache.CheckAndRecord(t.Context(), replayClient, "jti-1", future))
+	})
+
+	t.Run("exactly one caller wins under contention", func(t *testing.T) {
+		// The check and the record must be atomic, or two replicas both observe
+		// "unseen" and both accept.
+		cache := witwpt.NewMemoryReplayCache()
+
+		const goroutines = 50
+		var (
+			wg        sync.WaitGroup
+			mu        sync.Mutex
+			successes int
+		)
+		start := make(chan struct{})
+
+		for range goroutines {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				if err := cache.CheckAndRecord(t.Context(), replayClient, "contended", future); err == nil {
+					mu.Lock()
+					successes++
+					mu.Unlock()
+				}
+			}()
+		}
+
+		close(start)
+		wg.Wait()
+		assert.Equal(t, 1, successes, "exactly one caller may record a given jti")
+	})
+}

--- a/exp/witwpt/verify.go
+++ b/exp/witwpt/verify.go
@@ -1,0 +1,283 @@
+package witwpt
+
+import (
+	"context"
+	"crypto/subtle"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/spiffe/go-spiffe/v2/exp/bundle/witbundle"
+	"github.com/spiffe/go-spiffe/v2/exp/svid/witsvid"
+)
+
+// allowedProofAlgorithms mirrors the asymmetric algorithms witsvid permits for a
+// confirmation key. "none" and every symmetric algorithm are absent by
+// construction, as wpt-01 §2 requires.
+var allowedProofAlgorithms = []jose.SignatureAlgorithm{
+	jose.RS256, jose.RS384, jose.RS512,
+	jose.ES256, jose.ES384, jose.ES512,
+	jose.PS256, jose.PS384, jose.PS512,
+}
+
+// VerifyOption configures a Verifier.
+type VerifyOption interface {
+	configureVerify(*verifyConfig)
+}
+
+type verifyConfig struct {
+	replayCache ReplayCache
+	leeway      time.Duration
+	maxLifetime time.Duration
+}
+
+type verifyOption func(*verifyConfig)
+
+func (fn verifyOption) configureVerify(c *verifyConfig) { fn(c) }
+
+// WithReplayCache enables replay protection, rejecting a proof whose jti has
+// already been recorded for the presenting identity.
+//
+// This is off by default. NewMemoryReplayCache protects a single process only,
+// and defaulting it on would read like complete coverage while a deployment
+// running several replicas still accepted a proof replayed to another replica.
+func WithReplayCache(cache ReplayCache) VerifyOption {
+	return verifyOption(func(c *verifyConfig) {
+		c.replayCache = cache
+	})
+}
+
+// WithLeeway sets the clock-skew tolerance applied to a proof's exp and nbf,
+// overriding DefaultLeeway.
+//
+// Widening this lengthens the window in which a captured proof stays usable, so
+// prefer fixing clock synchronization.
+func WithLeeway(leeway time.Duration) VerifyOption {
+	return verifyOption(func(c *verifyConfig) {
+		c.leeway = leeway
+	})
+}
+
+// WithMaxProofLifetime sets how far into the future a proof's exp may sit,
+// overriding DefaultMaxLifetime.
+//
+// It also bounds the memory replay cache's footprint, since no record is kept
+// past it.
+func WithMaxProofLifetime(maxLifetime time.Duration) VerifyOption {
+	return verifyOption(func(c *verifyConfig) {
+		c.maxLifetime = maxLifetime
+	})
+}
+
+// Verifier validates a WIT-SVID and its proof of possession. Build one at
+// startup and share it: protocol settings are parsed once here rather than per
+// request, and every transport handed the same Verifier shares its replay cache
+// by construction.
+type Verifier struct {
+	bundles witbundle.Source
+	config  verifyConfig
+}
+
+// NewVerifier returns a Verifier validating WIT-SVIDs against bundles.
+func NewVerifier(bundles witbundle.Source, opts ...VerifyOption) *Verifier {
+	config := verifyConfig{
+		leeway:      DefaultLeeway,
+		maxLifetime: DefaultMaxLifetime,
+	}
+	for _, opt := range opts {
+		opt.configureVerify(&config)
+	}
+	return &Verifier{bundles: bundles, config: config}
+}
+
+// Verify authenticates a peer from the two raw tokens it presented, returning
+// the verified WIT-SVID. audience decides which aud values are acceptable for
+// this request and must not be nil.
+//
+// The order is normative and fixed: the WIT-SVID is validated against the trust
+// bundle first, and only then is the proof checked against the confirmation key
+// that credential named. Taking raw token strings rather than a parsed SVID is
+// what makes that ordering unskippable -- there is no way to route an
+// unvalidated witsvid.ParseInsecure result into proof verification.
+//
+// A failure is returned as *Error carrying the Stage that rejected it. Callers
+// surfacing this to a remote peer should not include the message.
+func (v *Verifier) Verify(ctx context.Context, witToken, wptToken string,
+	audience AudienceMatcher) (*witsvid.SVID, error) {
+	if audience == nil {
+		return nil, newError(StageProof, errors.New("no audience matcher provided"))
+	}
+	if witToken == "" {
+		return nil, newError(StageWIT, errors.New("no WIT-SVID token presented"))
+	}
+
+	// Step 1: the credential. Until this succeeds we have no key to trust.
+	svid, err := witsvid.ParseAndValidate(witToken, v.bundles)
+	if err != nil {
+		return nil, newError(StageWIT, err)
+	}
+
+	// Step 2: the proof, against the confirmation key the credential named.
+	claims, err := v.verifyProof(witToken, wptToken, svid)
+	if err != nil {
+		return nil, newError(StageProof, err)
+	}
+	if err := audience(claims.audience); err != nil {
+		return nil, newError(StageProof, err)
+	}
+
+	// Step 3: replay, once the identity is known so a jti cannot be claimed
+	// across workloads.
+	//
+	// The record must last as long as the proof remains *acceptable*, which is
+	// leeway past its exp -- not until exp itself. Recording only until exp would
+	// leave the whole leeway window unprotected, which is precisely the window in
+	// which a captured proof is most likely to be reused.
+	if v.config.replayCache != nil {
+		dropAfter := claims.expiry.Add(v.config.leeway)
+		if err := v.config.replayCache.CheckAndRecord(ctx, svid.ID, claims.id, dropAfter); err != nil {
+			return nil, newError(StageReplay, err)
+		}
+	}
+	return svid, nil
+}
+
+// proofClaims is the subset of a verified proof the verifier acts on.
+type proofClaims struct {
+	audience string
+	id       string
+	expiry   time.Time
+}
+
+func (v *Verifier) verifyProof(witToken, wptToken string, svid *witsvid.SVID) (proofClaims, error) {
+	var out proofClaims
+
+	if wptToken == "" {
+		return out, errors.New("no proof token presented")
+	}
+
+	tok, err := jwt.ParseSigned(wptToken, allowedProofAlgorithms)
+	if err != nil {
+		return out, fmt.Errorf("unable to parse proof token: %w", err)
+	}
+
+	header := tok.Headers[0]
+
+	// typ MUST be wpt+jwt, so a token minted for another purpose cannot be
+	// repurposed as a proof.
+	if typ, _ := header.ExtraHeaders[jose.HeaderType].(string); typ != proofType {
+		return out, fmt.Errorf("proof header type must be %q, got %q", proofType, typ)
+	}
+
+	// alg MUST string-equal the WIT's cnf.jwk.alg (wpt-01 §2), which pins the
+	// algorithm to the credential rather than letting the presenter choose.
+	expectedAlg, err := confirmationAlgorithm(svid)
+	if err != nil {
+		return out, err
+	}
+	if header.Algorithm != string(expectedAlg) {
+		return out, fmt.Errorf("proof alg %q does not match the WIT-SVID's cnf.jwk alg %q",
+			header.Algorithm, expectedAlg)
+	}
+
+	// The signature must verify under the confirmation public key. This is the
+	// proof of possession.
+	var raw map[string]any
+	if err := tok.Claims(svid.PublicKey, &raw); err != nil {
+		return out, fmt.Errorf("proof signature verification failed: %w", err)
+	}
+
+	// wth binds the proof to this exact credential. Recomputed from the token as
+	// received, so a re-serialization cannot shift the bytes.
+	wth, _ := raw["wth"].(string)
+	if wth == "" {
+		return out, errors.New("proof is missing the wth claim")
+	}
+	expectedWTH := WITThumbprint(witToken)
+	if subtle.ConstantTimeCompare([]byte(wth), []byte(expectedWTH)) != 1 {
+		return out, errors.New("proof wth claim is not bound to the presented WIT-SVID")
+	}
+
+	// jti is required regardless of whether a replay cache is configured.
+	jti, _ := raw["jti"].(string)
+	if jti == "" {
+		return out, errors.New("proof is missing the jti claim")
+	}
+
+	if err := rejectTokenBindings(raw); err != nil {
+		return out, err
+	}
+
+	var std jwt.Claims
+	if err := tok.UnsafeClaimsWithoutVerification(&std); err != nil {
+		return out, fmt.Errorf("unable to read proof claims: %w", err)
+	}
+	if std.Expiry == nil {
+		return out, errors.New("proof is missing the exp claim")
+	}
+
+	now := time.Now()
+	expiry := std.Expiry.Time()
+
+	// wpt-01 §2: unreasonably far future exp values SHOULD be rejected, or a
+	// client could mint a proof valid for a week.
+	if expiry.After(now.Add(v.config.maxLifetime + v.config.leeway)) {
+		return out, fmt.Errorf("proof exp is too far in the future (max lifetime %s)",
+			v.config.maxLifetime)
+	}
+
+	if err := std.ValidateWithLeeway(jwt.Expected{Time: now}, v.config.leeway); err != nil {
+		switch {
+		case errors.Is(err, jwt.ErrExpired):
+			// Named explicitly, because a proof this short-lived cannot tolerate
+			// large skew and the operator should look at NTP, not at audiences.
+			return out, fmt.Errorf("proof has expired (clock skew beyond %s is not tolerated)",
+				v.config.leeway)
+		case errors.Is(err, jwt.ErrNotValidYet):
+			return out, errors.New("proof is not yet valid")
+		default:
+			return out, err
+		}
+	}
+
+	audience, _ := raw["aud"].(string)
+	out = proofClaims{audience: audience, id: jti, expiry: expiry}
+	return out, nil
+}
+
+// bindingClaims are the WPT claims that bind a proof to some *other* credential
+// travelling with the request (wpt-01 §2): an OAuth access token, a Txn-Token, or
+// another end-user-context token.
+var bindingClaims = []string{"ath", "tth", "oth"}
+
+// rejectTokenBindings refuses a proof that binds a credential this package does
+// not model, rather than ignoring the binding.
+//
+// Failing closed is the important part. A conformant client that sets ath
+// believes its access token is cryptographically bound to this WIT-SVID; if the
+// verifier quietly discards that, a stolen bearer token presented alongside an
+// attacker's own valid WIT and proof looks bound and is not. wpt-01 §2 is also
+// explicit for oth: "If the oth claim contains entries that are not understood
+// by the recipient, the WPT MUST be rejected."
+//
+// Supporting these claims means consuming the bound credential too, which is out
+// of scope here. Until then a loud rejection beats an invisible hole.
+func rejectTokenBindings(raw map[string]any) error {
+	for _, claim := range bindingClaims {
+		if _, ok := raw[claim]; ok {
+			return fmt.Errorf("proof carries the %q claim, and token binding is not "+
+				"supported by this verifier", claim)
+		}
+	}
+	return nil
+}
+
+// Verify authenticates a peer using a verifier with default settings. Use
+// NewVerifier when a replay cache or non-default timings are wanted, or to avoid
+// rebuilding the verifier per request.
+func Verify(ctx context.Context, witToken, wptToken string, bundles witbundle.Source,
+	audience AudienceMatcher) (*witsvid.SVID, error) {
+	return NewVerifier(bundles).Verify(ctx, witToken, wptToken, audience)
+}

--- a/exp/witwpt/verify.go
+++ b/exp/witwpt/verify.go
@@ -14,8 +14,8 @@ import (
 )
 
 // allowedProofAlgorithms mirrors the asymmetric algorithms witsvid permits for a
-// confirmation key. "none" and every symmetric algorithm are absent by
-// construction, as wpt-01 §2 requires.
+// confirmation key. wpt-01 §2 requires "none" and symmetric algorithms be
+// rejected.
 var allowedProofAlgorithms = []jose.SignatureAlgorithm{
 	jose.RS256, jose.RS384, jose.RS512,
 	jose.ES256, jose.ES384, jose.ES512,
@@ -38,11 +38,9 @@ type verifyOption func(*verifyConfig)
 func (fn verifyOption) configureVerify(c *verifyConfig) { fn(c) }
 
 // WithReplayCache enables replay protection, rejecting a proof whose jti has
-// already been recorded for the presenting identity.
-//
-// This is off by default. NewMemoryReplayCache protects a single process only,
-// and defaulting it on would read like complete coverage while a deployment
-// running several replicas still accepted a proof replayed to another replica.
+// already been recorded for the presenting identity. It is off by default,
+// since NewMemoryReplayCache covers a single process only and enabling it by
+// default would look like complete coverage across replicas.
 func WithReplayCache(cache ReplayCache) VerifyOption {
 	return verifyOption(func(c *verifyConfig) {
 		c.replayCache = cache
@@ -50,10 +48,8 @@ func WithReplayCache(cache ReplayCache) VerifyOption {
 }
 
 // WithLeeway sets the clock-skew tolerance applied to a proof's exp and nbf,
-// overriding DefaultLeeway.
-//
-// Widening this lengthens the window in which a captured proof stays usable, so
-// prefer fixing clock synchronization.
+// overriding DefaultLeeway. Widening it lengthens the window in which a
+// captured proof stays usable.
 func WithLeeway(leeway time.Duration) VerifyOption {
 	return verifyOption(func(c *verifyConfig) {
 		c.leeway = leeway
@@ -61,20 +57,17 @@ func WithLeeway(leeway time.Duration) VerifyOption {
 }
 
 // WithMaxProofLifetime sets how far into the future a proof's exp may sit,
-// overriding DefaultMaxLifetime.
-//
-// It also bounds the memory replay cache's footprint, since no record is kept
-// past it.
+// overriding DefaultMaxLifetime. It also bounds the memory replay cache's
+// footprint, since no record is kept past it.
 func WithMaxProofLifetime(maxLifetime time.Duration) VerifyOption {
 	return verifyOption(func(c *verifyConfig) {
 		c.maxLifetime = maxLifetime
 	})
 }
 
-// Verifier validates a WIT-SVID and its proof of possession. Build one at
-// startup and share it: protocol settings are parsed once here rather than per
-// request, and every transport handed the same Verifier shares its replay cache
-// by construction.
+// Verifier validates a WIT-SVID and its proof of possession. It is safe for
+// concurrent use; build one at startup and share it so every transport shares
+// its settings and replay cache.
 type Verifier struct {
 	bundles witbundle.Source
 	config  verifyConfig
@@ -96,14 +89,12 @@ func NewVerifier(bundles witbundle.Source, opts ...VerifyOption) *Verifier {
 // the verified WIT-SVID. audience decides which aud values are acceptable for
 // this request and must not be nil.
 //
-// The order is normative and fixed: the WIT-SVID is validated against the trust
-// bundle first, and only then is the proof checked against the confirmation key
-// that credential named. Taking raw token strings rather than a parsed SVID is
-// what makes that ordering unskippable -- there is no way to route an
-// unvalidated witsvid.ParseInsecure result into proof verification.
+// It takes raw tokens rather than a parsed SVID so the normative order is
+// unskippable: the WIT-SVID is validated against the trust bundle first, and
+// only then is the proof checked against the confirmation key it named.
 //
-// A failure is returned as *Error carrying the Stage that rejected it. Callers
-// surfacing this to a remote peer should not include the message.
+// A failure is returned as *Error carrying the Stage that rejected it. Its
+// message should not be surfaced to a remote peer.
 func (v *Verifier) Verify(ctx context.Context, witToken, wptToken string,
 	audience AudienceMatcher) (*witsvid.SVID, error) {
 	if audience == nil {
@@ -113,7 +104,7 @@ func (v *Verifier) Verify(ctx context.Context, witToken, wptToken string,
 		return nil, newError(StageWIT, errors.New("no WIT-SVID token presented"))
 	}
 
-	// Step 1: the credential. Until this succeeds we have no key to trust.
+	// Step 1: the credential. Until this succeeds there is no key to trust.
 	svid, err := witsvid.ParseAndValidate(witToken, v.bundles)
 	if err != nil {
 		return nil, newError(StageWIT, err)
@@ -129,12 +120,8 @@ func (v *Verifier) Verify(ctx context.Context, witToken, wptToken string,
 	}
 
 	// Step 3: replay, once the identity is known so a jti cannot be claimed
-	// across workloads.
-	//
-	// The record must last as long as the proof remains *acceptable*, which is
-	// leeway past its exp -- not until exp itself. Recording only until exp would
-	// leave the whole leeway window unprotected, which is precisely the window in
-	// which a captured proof is most likely to be reused.
+	// across workloads. The record lasts leeway past exp, since that is how long
+	// the proof stays acceptable.
 	if v.config.replayCache != nil {
 		dropAfter := claims.expiry.Add(v.config.leeway)
 		if err := v.config.replayCache.CheckAndRecord(ctx, svid.ID, claims.id, dropAfter); err != nil {
@@ -165,14 +152,14 @@ func (v *Verifier) verifyProof(witToken, wptToken string, svid *witsvid.SVID) (p
 
 	header := tok.Headers[0]
 
-	// typ MUST be wpt+jwt, so a token minted for another purpose cannot be
-	// repurposed as a proof.
+	// typ MUST be wpt+jwt, so a token minted for another purpose cannot be used
+	// as a proof.
 	if typ, _ := header.ExtraHeaders[jose.HeaderType].(string); typ != proofType {
 		return out, fmt.Errorf("proof header type must be %q, got %q", proofType, typ)
 	}
 
-	// alg MUST string-equal the WIT's cnf.jwk.alg (wpt-01 §2), which pins the
-	// algorithm to the credential rather than letting the presenter choose.
+	// alg MUST string-equal the WIT's cnf.jwk.alg (wpt-01 §2), so the presenter
+	// cannot choose it.
 	expectedAlg, err := confirmationAlgorithm(svid)
 	if err != nil {
 		return out, err
@@ -182,15 +169,15 @@ func (v *Verifier) verifyProof(witToken, wptToken string, svid *witsvid.SVID) (p
 			header.Algorithm, expectedAlg)
 	}
 
-	// The signature must verify under the confirmation public key. This is the
+	// The signature must verify under the confirmation public key: this is the
 	// proof of possession.
 	var raw map[string]any
 	if err := tok.Claims(svid.PublicKey, &raw); err != nil {
 		return out, fmt.Errorf("proof signature verification failed: %w", err)
 	}
 
-	// wth binds the proof to this exact credential. Recomputed from the token as
-	// received, so a re-serialization cannot shift the bytes.
+	// wth binds the proof to this exact credential, recomputed over the token as
+	// received so a re-serialization cannot shift the bytes.
 	wth, _ := raw["wth"].(string)
 	if wth == "" {
 		return out, errors.New("proof is missing the wth claim")
@@ -221,8 +208,7 @@ func (v *Verifier) verifyProof(witToken, wptToken string, svid *witsvid.SVID) (p
 	now := time.Now()
 	expiry := std.Expiry.Time()
 
-	// wpt-01 §2: unreasonably far future exp values SHOULD be rejected, or a
-	// client could mint a proof valid for a week.
+	// wpt-01 §2: unreasonably far future exp values SHOULD be rejected.
 	if expiry.After(now.Add(v.config.maxLifetime + v.config.leeway)) {
 		return out, fmt.Errorf("proof exp is too far in the future (max lifetime %s)",
 			v.config.maxLifetime)
@@ -231,8 +217,7 @@ func (v *Verifier) verifyProof(witToken, wptToken string, svid *witsvid.SVID) (p
 	if err := std.ValidateWithLeeway(jwt.Expected{Time: now}, v.config.leeway); err != nil {
 		switch {
 		case errors.Is(err, jwt.ErrExpired):
-			// Named explicitly, because a proof this short-lived cannot tolerate
-			// large skew and the operator should look at NTP, not at audiences.
+			// The leeway is named so an operator sees skew, not policy, as the cause.
 			return out, fmt.Errorf("proof has expired (clock skew beyond %s is not tolerated)",
 				v.config.leeway)
 		case errors.Is(err, jwt.ErrNotValidYet):
@@ -247,23 +232,14 @@ func (v *Verifier) verifyProof(witToken, wptToken string, svid *witsvid.SVID) (p
 	return out, nil
 }
 
-// bindingClaims are the WPT claims that bind a proof to some *other* credential
+// bindingClaims are the WPT claims that bind a proof to some other credential
 // travelling with the request (wpt-01 §2): an OAuth access token, a Txn-Token, or
 // another end-user-context token.
 var bindingClaims = []string{"ath", "tth", "oth"}
 
-// rejectTokenBindings refuses a proof that binds a credential this package does
-// not model, rather than ignoring the binding.
-//
-// Failing closed is the important part. A conformant client that sets ath
-// believes its access token is cryptographically bound to this WIT-SVID; if the
-// verifier quietly discards that, a stolen bearer token presented alongside an
-// attacker's own valid WIT and proof looks bound and is not. wpt-01 §2 is also
-// explicit for oth: "If the oth claim contains entries that are not understood
-// by the recipient, the WPT MUST be rejected."
-//
-// Supporting these claims means consuming the bound credential too, which is out
-// of scope here. Until then a loud rejection beats an invisible hole.
+// rejectTokenBindings fails closed on a binding this package does not model.
+// Ignoring one would let a stolen bearer token look bound when it is not, and
+// wpt-01 §2 requires rejecting an oth entry the recipient does not understand.
 func rejectTokenBindings(raw map[string]any) error {
 	for _, claim := range bindingClaims {
 		if _, ok := raw[claim]; ok {

--- a/exp/witwpt/verify_test.go
+++ b/exp/witwpt/verify_test.go
@@ -1,0 +1,516 @@
+package witwpt_test
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/spiffe/go-spiffe/v2/exp/bundle/witbundle"
+	"github.com/spiffe/go-spiffe/v2/exp/witwpt"
+	"github.com/spiffe/go-spiffe/v2/internal/test"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Verify is deliberately never fed by Mint. We author both halves of the wire
+// format, so a shared misreading of the draft would make a loopback test pass
+// while the format is wrong. Proofs here are built by makeWPT, a local go-jose
+// minter, and Mint is pinned separately against committed constants.
+
+const verifyAudience = "https://server.example.org/v2/orders"
+
+type verifyFixture struct {
+	bundle    *witbundle.Bundle
+	witToken  string
+	cnfKey    *ecdsa.PrivateKey
+	authority *ecdsa.PrivateKey
+	id        spiffeid.ID
+	td        spiffeid.TrustDomain
+}
+
+func newVerifyFixture(t *testing.T) *verifyFixture {
+	t.Helper()
+
+	td := spiffeid.RequireTrustDomainFromString("example.org")
+	id := spiffeid.RequireFromPath(td, "/client")
+	authority := test.NewEC256Key(t)
+	cnfKey := test.NewEC256Key(t)
+	const kid = "authority-1"
+
+	bundle := witbundle.New(td)
+	require.NoError(t, bundle.AddWITAuthority(kid, authority.Public()))
+
+	witToken := makeWIT(t, authority, kid, id, cnfKey.Public(), jose.ES256,
+		time.Now().Add(time.Hour))
+
+	return &verifyFixture{
+		bundle:    bundle,
+		witToken:  witToken,
+		cnfKey:    cnfKey,
+		authority: authority,
+		id:        id,
+		td:        td,
+	}
+}
+
+// validProofClaims returns the claims of a proof that should verify.
+func (f *verifyFixture) validProofClaims() map[string]any {
+	return map[string]any{
+		"aud": verifyAudience,
+		"exp": jwt.NewNumericDate(time.Now().Add(witwpt.DefaultProofLifetime)),
+		"jti": "jti-fixture-0001",
+		"wth": witwpt.WITThumbprint(f.witToken),
+	}
+}
+
+func TestVerifyAcceptsAValidPair(t *testing.T) {
+	f := newVerifyFixture(t)
+	proof := makeWPT(t, f.cnfKey, jose.ES256, "wpt+jwt", f.validProofClaims())
+
+	svid, err := witwpt.Verify(t.Context(), f.witToken, proof, f.bundle,
+		witwpt.AcceptAudience("https://server.example.org"))
+	require.NoError(t, err)
+	require.NotNil(t, svid)
+
+	assert.Equal(t, f.id, svid.ID, "the identity comes from the WIT-SVID's sub claim")
+	assert.Equal(t, f.witToken, svid.Marshal())
+	assert.Contains(t, svid.Claims, "cnf")
+}
+
+func TestVerifyRejections(t *testing.T) {
+	tests := []struct {
+		name  string
+		stage witwpt.Stage
+		// proof builds the proof token; wit optionally overrides the WIT token.
+		proof   func(*testing.T, *verifyFixture) string
+		wit     func(*testing.T, *verifyFixture) string
+		errPart string
+	}{
+		{
+			name:    "proof is missing",
+			stage:   witwpt.StageProof,
+			proof:   func(*testing.T, *verifyFixture) string { return "" },
+			errPart: "no proof token",
+		},
+		{
+			name:    "proof is malformed",
+			stage:   witwpt.StageProof,
+			proof:   func(*testing.T, *verifyFixture) string { return "not.a.jwt" },
+			errPart: "unable to parse",
+		},
+		{
+			name:  "proof signed by a key other than cnf.jwk",
+			stage: witwpt.StageProof,
+			proof: func(t *testing.T, f *verifyFixture) string {
+				unrelated := test.NewEC256Key(t)
+				return makeWPT(t, unrelated, jose.ES256, "wpt+jwt", f.validProofClaims())
+			},
+			errPart: "signature",
+		},
+		{
+			name:  "proof alg does not match cnf.jwk.alg",
+			stage: witwpt.StageProof,
+			proof: func(t *testing.T, f *verifyFixture) string {
+				// The confirmation key is P-256/ES256; sign ES512 instead.
+				key := test.NewEC256Key(t)
+				return makeWPT(t, key, jose.ES256, "wpt+jwt", f.validProofClaims())
+			},
+			wit: func(t *testing.T, f *verifyFixture) string {
+				// Declare a different alg in cnf.jwk so alg equality fails first.
+				return makeWIT(t, f.authority, "authority-1", f.id, f.cnfKey.Public(),
+					jose.ES512, time.Now().Add(time.Hour))
+			},
+			errPart: "alg",
+		},
+		{
+			name:  "proof signed with a different algorithm than cnf.jwk.alg",
+			stage: witwpt.StageProof,
+			proof: func(t *testing.T, f *verifyFixture) string {
+				// A genuinely ES384-signed proof against an ES256 confirmation
+				// key, rather than a mislabelled header.
+				key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+				require.NoError(t, err)
+				return makeWPT(t, key, jose.ES384, "wpt+jwt", f.validProofClaims())
+			},
+			errPart: "does not match",
+		},
+		{
+			name:  "WIT kid names an authority the bundle does not hold",
+			stage: witwpt.StageWIT,
+			wit: func(t *testing.T, f *verifyFixture) string {
+				return makeWIT(t, f.authority, "rotated-away", f.id, f.cnfKey.Public(),
+					jose.ES256, time.Now().Add(time.Hour))
+			},
+			errPart: "no WIT authority",
+		},
+		{
+			name:  "proof binds an OAuth access token via ath",
+			stage: witwpt.StageProof,
+			proof: func(t *testing.T, f *verifyFixture) string {
+				// wpt-01 §2 makes ath mandatory when an access token is present.
+				// This package does not consume it, so accepting the proof would
+				// silently discard a binding the client believes is enforced --
+				// a stolen bearer token would travel with a valid pair and look
+				// bound. Fail closed instead.
+				claims := f.validProofClaims()
+				claims["ath"] = "Zm9vYmFy"
+				return makeWPT(t, f.cnfKey, jose.ES256, "wpt+jwt", claims)
+			},
+			errPart: "token binding",
+		},
+		{
+			name:  "proof binds a Txn-Token via tth",
+			stage: witwpt.StageProof,
+			proof: func(t *testing.T, f *verifyFixture) string {
+				claims := f.validProofClaims()
+				claims["tth"] = "Zm9vYmFy"
+				return makeWPT(t, f.cnfKey, jose.ES256, "wpt+jwt", claims)
+			},
+			errPart: "token binding",
+		},
+		{
+			name:  "proof carries oth entries this verifier does not understand",
+			stage: witwpt.StageProof,
+			proof: func(t *testing.T, f *verifyFixture) string {
+				// wpt-01 §2: "If the oth claim contains entries that are not
+				// understood by the recipient, the WPT MUST be rejected."
+				claims := f.validProofClaims()
+				claims["oth"] = map[string]any{"x-vendor-assertion": "Zm9vYmFy"}
+				return makeWPT(t, f.cnfKey, jose.ES256, "wpt+jwt", claims)
+			},
+			errPart: "token binding",
+		},
+		{
+			name:  "proof typ is not wpt+jwt",
+			stage: witwpt.StageProof,
+			proof: func(t *testing.T, f *verifyFixture) string {
+				return makeWPT(t, f.cnfKey, jose.ES256, "jwt", f.validProofClaims())
+			},
+			errPart: "wpt+jwt",
+		},
+		{
+			name:  "proof is bound to a different WIT",
+			stage: witwpt.StageProof,
+			proof: func(t *testing.T, f *verifyFixture) string {
+				other := makeWIT(t, f.authority, "authority-1", f.id, f.cnfKey.Public(),
+					jose.ES256, time.Now().Add(2*time.Hour))
+				claims := f.validProofClaims()
+				claims["wth"] = witwpt.WITThumbprint(other)
+				return makeWPT(t, f.cnfKey, jose.ES256, "wpt+jwt", claims)
+			},
+			errPart: "wth",
+		},
+		{
+			name:  "proof is missing wth",
+			stage: witwpt.StageProof,
+			proof: func(t *testing.T, f *verifyFixture) string {
+				claims := f.validProofClaims()
+				delete(claims, "wth")
+				return makeWPT(t, f.cnfKey, jose.ES256, "wpt+jwt", claims)
+			},
+			errPart: "wth",
+		},
+		{
+			name:  "proof is for another target",
+			stage: witwpt.StageProof,
+			proof: func(t *testing.T, f *verifyFixture) string {
+				claims := f.validProofClaims()
+				claims["aud"] = "https://elsewhere.example.org/v2/orders"
+				return makeWPT(t, f.cnfKey, jose.ES256, "wpt+jwt", claims)
+			},
+			errPart: "not accepted here",
+		},
+		{
+			name:  "proof has expired",
+			stage: witwpt.StageProof,
+			proof: func(t *testing.T, f *verifyFixture) string {
+				claims := f.validProofClaims()
+				claims["exp"] = jwt.NewNumericDate(time.Now().Add(-time.Hour))
+				return makeWPT(t, f.cnfKey, jose.ES256, "wpt+jwt", claims)
+			},
+			errPart: "expired",
+		},
+		{
+			name:  "proof exp is implausibly distant",
+			stage: witwpt.StageProof,
+			proof: func(t *testing.T, f *verifyFixture) string {
+				claims := f.validProofClaims()
+				claims["exp"] = jwt.NewNumericDate(time.Now().Add(7 * 24 * time.Hour))
+				return makeWPT(t, f.cnfKey, jose.ES256, "wpt+jwt", claims)
+			},
+			errPart: "too far in the future",
+		},
+		{
+			name:  "proof is missing exp",
+			stage: witwpt.StageProof,
+			proof: func(t *testing.T, f *verifyFixture) string {
+				claims := f.validProofClaims()
+				delete(claims, "exp")
+				return makeWPT(t, f.cnfKey, jose.ES256, "wpt+jwt", claims)
+			},
+			errPart: "exp",
+		},
+		{
+			name:  "proof is missing jti",
+			stage: witwpt.StageProof,
+			proof: func(t *testing.T, f *verifyFixture) string {
+				claims := f.validProofClaims()
+				delete(claims, "jti")
+				return makeWPT(t, f.cnfKey, jose.ES256, "wpt+jwt", claims)
+			},
+			errPart: "jti",
+		},
+		{
+			name:    "WIT is missing",
+			stage:   witwpt.StageWIT,
+			wit:     func(*testing.T, *verifyFixture) string { return "" },
+			errPart: "no WIT-SVID token",
+		},
+		{
+			name:    "WIT is malformed",
+			stage:   witwpt.StageWIT,
+			wit:     func(*testing.T, *verifyFixture) string { return "not.a.jwt" },
+			errPart: "witsvid",
+		},
+		{
+			name:  "WIT has expired",
+			stage: witwpt.StageWIT,
+			wit: func(t *testing.T, f *verifyFixture) string {
+				return makeWIT(t, f.authority, "authority-1", f.id, f.cnfKey.Public(),
+					jose.ES256, time.Now().Add(-time.Hour))
+			},
+			errPart: "expired",
+		},
+		{
+			name:  "WIT signed by an authority not in the bundle",
+			stage: witwpt.StageWIT,
+			wit: func(t *testing.T, f *verifyFixture) string {
+				imposter := test.NewEC256Key(t)
+				return makeWIT(t, imposter, "authority-1", f.id, f.cnfKey.Public(),
+					jose.ES256, time.Now().Add(time.Hour))
+			},
+			errPart: "signature verification failed",
+		},
+		{
+			name:  "WIT from an unfederated trust domain",
+			stage: witwpt.StageWIT,
+			wit: func(t *testing.T, f *verifyFixture) string {
+				otherTD := spiffeid.RequireTrustDomainFromString("other.org")
+				return makeWIT(t, f.authority, "authority-1",
+					spiffeid.RequireFromPath(otherTD, "/client"), f.cnfKey.Public(),
+					jose.ES256, time.Now().Add(time.Hour))
+			},
+			errPart: "no WIT bundle found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newVerifyFixture(t)
+
+			witToken := f.witToken
+			if tt.wit != nil {
+				witToken = tt.wit(t, f)
+			}
+
+			// Rebuild valid proof claims against whichever WIT is being sent, so
+			// only the property under test is wrong.
+			proof := makeWPT(t, f.cnfKey, jose.ES256, "wpt+jwt", map[string]any{
+				"aud": verifyAudience,
+				"exp": jwt.NewNumericDate(time.Now().Add(witwpt.DefaultProofLifetime)),
+				"jti": "jti-fixture-0001",
+				"wth": witwpt.WITThumbprint(witToken),
+			})
+			if tt.proof != nil {
+				proof = tt.proof(t, f)
+			}
+
+			svid, err := witwpt.Verify(t.Context(), witToken, proof, f.bundle,
+				witwpt.AcceptAudience("https://server.example.org"))
+
+			require.Error(t, err)
+			assert.Nil(t, svid)
+			assert.ErrorContains(t, err, tt.errPart)
+
+			var verr *witwpt.Error
+			require.ErrorAs(t, err, &verr, "failures must carry a machine-readable stage")
+			assert.Equal(t, tt.stage, verr.Stage)
+		})
+	}
+}
+
+func TestVerifyValidatesTheWITBeforeTheProof(t *testing.T) {
+	// The ordering is normative: the proof can only be checked against a cnf key
+	// the WIT has already been trusted to carry. With both halves broken, the
+	// WIT failure must be the one reported.
+	f := newVerifyFixture(t)
+
+	expiredWIT := makeWIT(t, f.authority, "authority-1", f.id, f.cnfKey.Public(),
+		jose.ES256, time.Now().Add(-time.Hour))
+	garbageProof := "not.a.jwt"
+
+	_, err := witwpt.Verify(t.Context(), expiredWIT, garbageProof, f.bundle,
+		witwpt.AcceptAudience("https://server.example.org"))
+
+	var verr *witwpt.Error
+	require.ErrorAs(t, err, &verr)
+	assert.Equal(t, witwpt.StageWIT, verr.Stage)
+}
+
+func TestVerifyReplayCache(t *testing.T) {
+	f := newVerifyFixture(t)
+	proof := makeWPT(t, f.cnfKey, jose.ES256, "wpt+jwt", f.validProofClaims())
+	audience := witwpt.AcceptAudience("https://server.example.org")
+
+	t.Run("without a cache a proof may be presented twice", func(t *testing.T) {
+		verifier := witwpt.NewVerifier(f.bundle)
+		_, err := verifier.Verify(t.Context(), f.witToken, proof, audience)
+		require.NoError(t, err)
+		_, err = verifier.Verify(t.Context(), f.witToken, proof, audience)
+		require.NoError(t, err, "replay protection is opt-in")
+	})
+
+	t.Run("with a cache the second presentation is rejected", func(t *testing.T) {
+		verifier := witwpt.NewVerifier(f.bundle,
+			witwpt.WithReplayCache(witwpt.NewMemoryReplayCache()))
+
+		_, err := verifier.Verify(t.Context(), f.witToken, proof, audience)
+		require.NoError(t, err)
+
+		_, err = verifier.Verify(t.Context(), f.witToken, proof, audience)
+		require.Error(t, err)
+
+		var verr *witwpt.Error
+		require.ErrorAs(t, err, &verr)
+		assert.Equal(t, witwpt.StageReplay, verr.Stage)
+	})
+
+	t.Run("a proof still inside the leeway window cannot be replayed", func(t *testing.T) {
+		// The record must outlive the proof's *acceptability*, not its exp. A
+		// proof whose exp has just passed is still accepted thanks to leeway, so
+		// recording it only until exp would leave replay unprotected for the
+		// whole leeway window -- the one window where a captured proof is most
+		// likely to be reused.
+		verifier := witwpt.NewVerifier(f.bundle,
+			witwpt.WithReplayCache(witwpt.NewMemoryReplayCache()))
+
+		claims := f.validProofClaims()
+		claims["exp"] = jwt.NewNumericDate(time.Now().Add(-witwpt.DefaultLeeway / 2))
+		expiring := makeWPT(t, f.cnfKey, jose.ES256, "wpt+jwt", claims)
+
+		_, err := verifier.Verify(t.Context(), f.witToken, expiring, audience)
+		require.NoError(t, err, "precondition: leeway still accepts this proof")
+
+		_, err = verifier.Verify(t.Context(), f.witToken, expiring, audience)
+		require.Error(t, err, "the replay must be rejected")
+
+		var verr *witwpt.Error
+		require.ErrorAs(t, err, &verr)
+		assert.Equal(t, witwpt.StageReplay, verr.Stage)
+	})
+}
+
+func TestVerifyWithMaxProofLifetime(t *testing.T) {
+	f := newVerifyFixture(t)
+	audience := witwpt.AcceptAudience("https://server.example.org")
+
+	claims := f.validProofClaims()
+	claims["exp"] = jwt.NewNumericDate(time.Now().Add(30 * time.Minute))
+	proof := makeWPT(t, f.cnfKey, jose.ES256, "wpt+jwt", claims)
+
+	t.Run("rejected under the default maximum", func(t *testing.T) {
+		_, err := witwpt.NewVerifier(f.bundle).Verify(t.Context(), f.witToken, proof, audience)
+		require.ErrorContains(t, err, "too far in the future")
+	})
+
+	t.Run("accepted when the operator raises the maximum", func(t *testing.T) {
+		verifier := witwpt.NewVerifier(f.bundle, witwpt.WithMaxProofLifetime(time.Hour))
+		_, err := verifier.Verify(t.Context(), f.witToken, proof, audience)
+		require.NoError(t, err)
+	})
+}
+
+func TestVerifyWithLeeway(t *testing.T) {
+	f := newVerifyFixture(t)
+	audience := witwpt.AcceptAudience("https://server.example.org")
+
+	// Expired by 30s: inside a 60s leeway, outside the 10s default.
+	claims := f.validProofClaims()
+	claims["exp"] = jwt.NewNumericDate(time.Now().Add(-30 * time.Second))
+	proof := makeWPT(t, f.cnfKey, jose.ES256, "wpt+jwt", claims)
+
+	t.Run("rejected under the default leeway", func(t *testing.T) {
+		_, err := witwpt.NewVerifier(f.bundle).Verify(t.Context(), f.witToken, proof, audience)
+		require.ErrorContains(t, err, "expired")
+	})
+
+	t.Run("accepted when the operator widens the leeway", func(t *testing.T) {
+		verifier := witwpt.NewVerifier(f.bundle, witwpt.WithLeeway(60*time.Second))
+		_, err := verifier.Verify(t.Context(), f.witToken, proof, audience)
+		require.NoError(t, err)
+	})
+}
+
+func TestVerifyRequiresAnAudienceMatcher(t *testing.T) {
+	f := newVerifyFixture(t)
+	proof := makeWPT(t, f.cnfKey, jose.ES256, "wpt+jwt", f.validProofClaims())
+
+	// A nil matcher must fail closed rather than accept any audience.
+	_, err := witwpt.Verify(t.Context(), f.witToken, proof, f.bundle, nil)
+	require.ErrorContains(t, err, "no audience matcher")
+}
+
+// --- local minters ---
+
+// makeWIT builds a WIT-SVID signed by authority, declaring cnfPub as the
+// confirmation key with the given alg.
+func makeWIT(t *testing.T, authority *ecdsa.PrivateKey, kid string, id spiffeid.ID,
+	cnfPub crypto.PublicKey, cnfAlg jose.SignatureAlgorithm, exp time.Time) string {
+	t.Helper()
+
+	cnfJWK := jose.JSONWebKey{Key: cnfPub, KeyID: "cnf-1", Algorithm: string(cnfAlg)}
+	cnfBytes, err := cnfJWK.MarshalJSON()
+	require.NoError(t, err)
+	var cnfMap map[string]any
+	require.NoError(t, json.Unmarshal(cnfBytes, &cnfMap))
+
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.ES256, Key: jose.JSONWebKey{Key: authority, KeyID: kid}},
+		(&jose.SignerOptions{}).WithType("wit+jwt"),
+	)
+	require.NoError(t, err)
+
+	token, err := jwt.Signed(signer).Claims(map[string]any{
+		"sub": id.String(),
+		"exp": jwt.NewNumericDate(exp),
+		"iat": jwt.NewNumericDate(time.Now()),
+		"cnf": map[string]any{"jwk": cnfMap},
+	}).Serialize()
+	require.NoError(t, err)
+	return token
+}
+
+// makeWPT builds a proof token with full control over its alg, typ, and claims,
+// so each verification rule can be violated in isolation.
+func makeWPT(t *testing.T, key crypto.Signer, alg jose.SignatureAlgorithm, typ string,
+	claims map[string]any) string {
+	t.Helper()
+
+	opts := &jose.SignerOptions{}
+	if typ != "" {
+		opts = opts.WithType(jose.ContentType(typ))
+	}
+	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: alg, Key: key}, opts)
+	require.NoError(t, err)
+
+	token, err := jwt.Signed(signer).Claims(claims).Serialize()
+	require.NoError(t, err)
+	return token
+}

--- a/workloadapi/witsource.go
+++ b/workloadapi/witsource.go
@@ -125,6 +125,25 @@ func (s *WITSource) Close() error {
 	return s.closeBase(closer)
 }
 
+// GetWITSVID returns the default WIT-SVID, which is the first one in the list
+// returned by the Workload API (see the SPIFFE Workload API specification §8).
+// It implements the witsvid.Source interface.
+//
+// Experimental: subject to change.
+func (s *WITSource) GetWITSVID() (*witsvid.SVID, error) {
+	if err := s.checkClosed(); err != nil {
+		return nil, err
+	}
+
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+
+	if len(s.svids) == 0 {
+		return nil, errors.New("witsource: no WIT-SVID available")
+	}
+	return s.svids[0], nil
+}
+
 // GetWITSVIDForID returns the WIT-SVID for the given SPIFFE ID.
 // It implements the witsvid.Source interface.
 //

--- a/workloadapi/witsource_test.go
+++ b/workloadapi/witsource_test.go
@@ -71,6 +71,41 @@ func TestWITSourceLookup(t *testing.T) {
 	})
 }
 
+func TestWITSourceGetWITSVID(t *testing.T) {
+	t.Run("returns the first SVID as the default identity", func(t *testing.T) {
+		api := fakeworkloadapi.New(t)
+		t.Cleanup(api.Stop)
+
+		key := test.NewEC256Key(t)
+		kid := "key-1"
+		api.SetWITSVIDResponse(&workload.WITSVIDResponse{
+			Svids: []*workload.WITSVID{
+				makeWITSVIDProto(t, witFooID, key, test.NewEC256Key(t), kid, ""),
+				makeWITSVIDProto(t, witBarID, key, test.NewEC256Key(t), kid, ""),
+			},
+		})
+		api.SetWITBundles(makeWITBundle(t, witTD, key, kid))
+
+		src, err := workloadapi.NewWITSource(t.Context(), withAddr(api))
+		require.NoError(t, err)
+		t.Cleanup(func() { src.Close() })
+
+		svid, err := src.GetWITSVID()
+		require.NoError(t, err)
+		assert.Equal(t, witFooID, svid.ID)
+	})
+
+	t.Run("errors when the source holds no SVIDs", func(t *testing.T) {
+		// Not reachable through NewWITSource: parseWITSVIDs rejects an empty
+		// response and watchWITSVIDs routes that to OnWITSVIDsWatchError, so
+		// OnWITSVIDsUpdate never delivers an empty slice. The branch is
+		// defensive; this pins its error rather than a nil SVID.
+		var src workloadapi.WITSource
+		_, err := src.GetWITSVID()
+		require.EqualError(t, err, "witsource: no WIT-SVID available")
+	})
+}
+
 func TestWITSourceClose(t *testing.T) {
 	api := fakeworkloadapi.New(t)
 	t.Cleanup(api.Stop)
@@ -80,6 +115,9 @@ func TestWITSourceClose(t *testing.T) {
 
 	t.Run("post-close calls return error", func(t *testing.T) {
 		_, err := src.GetWITSVIDForID(witFooID)
+		require.EqualError(t, err, "witsource: source is closed")
+
+		_, err = src.GetWITSVID()
 		require.EqualError(t, err, "witsource: source is closed")
 
 		_, err = src.GetWITBundleForTrustDomain(witTD)


### PR DESCRIPTION
Adds exp/witwpt, the transport-neutral implementation of the Workload Proof Token protocol, and exp/withttp, its net/http integration. 
A client mints a short-lived proof signed with the WIT-SVID's cnf key; a verifier validates the credential against its trust bundle before checking that proof.

Also adds a Claims field to witsvid.SVID, populated from data parse
already had in hand.

Depends of https://github.com/spiffe/go-spiffe/pull/410