### PR TITLE
Add exp/witwpt with WPT minting and policy helpers

### DIFF
--- a/exp/svid/witsvid/source.go
+++ b/exp/svid/witsvid/source.go
@@ -2,8 +2,12 @@ package witsvid
 
 import "github.com/spiffe/go-spiffe/v2/spiffeid"
 
-// Source is a source of WIT-SVIDs keyed by SPIFFE ID.
+// Source is a source of WIT-SVIDs.
 type Source interface {
+	// GetWITSVID returns the default WIT-SVID from the source. It is used by
+	// code that presents a credential and therefore has no ID to look up.
+	GetWITSVID() (*SVID, error)
+
 	// GetWITSVIDForID returns the WIT-SVID for the given SPIFFE ID.
 	GetWITSVIDForID(id spiffeid.ID) (*SVID, error)
 }

--- a/exp/svid/witsvid/svid.go
+++ b/exp/svid/witsvid/svid.go
@@ -52,6 +52,9 @@ type SVID struct {
 	// identity should be used by a workload when more than one SVID is returned.
 	Hint string
 
+	// Claims is the parsed claims from the WIT-SVID token.
+	Claims map[string]interface{}
+
 	// token is the serialized JWS compact serialization.
 	token string
 }
@@ -167,6 +170,7 @@ func parse(token string, verify verifyFn) (*SVID, error) {
 		Expiry:    stdClaims.Expiry.Time().UTC(),
 		PublicKey: publicKey,
 		KeyID:     keyID,
+		Claims:    rawClaims,
 		token:     token,
 	}, nil
 }

--- a/exp/svid/witsvid/svid_test.go
+++ b/exp/svid/witsvid/svid_test.go
@@ -68,6 +68,20 @@ func TestParseInsecure(t *testing.T) {
 			}),
 		},
 		{
+			name: "issuer-supplied claims are exposed",
+			token: withClaims(func(c map[string]any) {
+				c["groups"] = []string{"admin", "ops"}
+			}),
+			check: func(t *testing.T, svid *witsvid.SVID) {
+				// Issuer-supplied claims are reachable by a verifier.
+				assert.Equal(t, []any{"admin", "ops"}, svid.Claims["groups"])
+				// Standard and confirmation claims come through untouched.
+				assert.Equal(t, workload.String(), svid.Claims["sub"])
+				assert.Contains(t, svid.Claims, "exp")
+				assert.Contains(t, svid.Claims, "cnf")
+			},
+		},
+		{
 			name:  "malformed",
 			token: func(*testing.T) string { return "not.a.valid.jwt" },
 			err:   "witsvid: unable to parse WIT-SVID token",

--- a/exp/witwpt/audience.go
+++ b/exp/witwpt/audience.go
@@ -13,12 +13,10 @@ type AudienceMatcher func(aud string) error
 
 // AcceptAudience returns an AudienceMatcher that matches aud against values,
 // normalizing both sides to scheme and authority as wpt-01 §2's "acceptable
-// alias or normalization" allows: the scheme and host are lowercased, and a
-// default port, path, query, and fragment are dropped.
-//
-// Dropping the path means a proof is bound to an authority, not to a route, so
-// any endpoint on that hostname accepts a captured pair for the proof's
-// lifetime; WithReplayCache narrows that, a path in a configured value does not.
+// alias or normalization" allows: scheme and host are lowercased, and a default
+// port, path, query, and fragment are dropped. A proof is therefore bound to an
+// authority, not to a route; use WithReplayCache to narrow that, since a path in
+// a configured value is ignored.
 //
 // A value that cannot be normalized is kept verbatim, so it never matches and
 // still appears in the mismatch error.

--- a/exp/witwpt/audience.go
+++ b/exp/witwpt/audience.go
@@ -1,0 +1,95 @@
+package witwpt
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// AudienceMatcher decides whether a WPT's aud claim is acceptable for this
+// request. It is called with the aud claim exactly as it appeared in the proof.
+type AudienceMatcher func(aud string) error
+
+// AcceptAudience returns an AudienceMatcher that matches aud against values,
+// normalizing both sides to scheme and authority as wpt-01 §2's "acceptable
+// alias or normalization" allows: the scheme and host are lowercased, and a
+// default port, path, query, and fragment are dropped.
+//
+// Dropping the path means a proof is bound to an authority, not to a route, so
+// any endpoint on that hostname accepts a captured pair for the proof's
+// lifetime; WithReplayCache narrows that, a path in a configured value does not.
+//
+// A value that cannot be normalized is kept verbatim, so it never matches and
+// still appears in the mismatch error.
+func AcceptAudience(values ...string) AudienceMatcher {
+	accepted := make([]string, 0, len(values))
+	for _, value := range values {
+		normalized, err := normalizeAudience(value)
+		if err != nil {
+			normalized = value
+		}
+		accepted = append(accepted, normalized)
+	}
+
+	return func(aud string) error {
+		if aud == "" {
+			return wrapErr(errors.New("proof is missing the aud claim"))
+		}
+
+		normalized, err := normalizeAudience(aud)
+		if err != nil {
+			return wrapErr(fmt.Errorf("proof audience %q is not a valid absolute URI", aud))
+		}
+
+		for _, candidate := range accepted {
+			if normalized == candidate {
+				return nil
+			}
+		}
+
+		// Both sides are named so a proxy or port misconfiguration is diagnosable
+		// from one log line.
+		return wrapErr(fmt.Errorf("proof audience %q is not accepted here (expected one of %q)",
+			aud, accepted))
+	}
+}
+
+// normalizeAudience reduces an absolute URI to scheme://authority, dropping the
+// default port for the scheme along with any path, query, and fragment.
+func normalizeAudience(value string) (string, error) {
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return "", err
+	}
+
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme == "" || parsed.Host == "" {
+		return "", fmt.Errorf("not an absolute URI: %q", value)
+	}
+
+	host := strings.ToLower(parsed.Hostname())
+	if host == "" {
+		return "", fmt.Errorf("no host in %q", value)
+	}
+
+	if port := parsed.Port(); port != "" && !isDefaultPort(scheme, port) {
+		host = host + ":" + port
+	}
+	return scheme + "://" + host, nil
+}
+
+func isDefaultPort(scheme, port string) bool {
+	switch scheme {
+	case "https":
+		return port == "443"
+	case "http":
+		return port == "80"
+	default:
+		return false
+	}
+}
+
+func wrapErr(err error) error {
+	return fmt.Errorf("witwpt: %w", err)
+}

--- a/exp/witwpt/audience_test.go
+++ b/exp/witwpt/audience_test.go
@@ -1,0 +1,132 @@
+package witwpt_test
+
+import (
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/exp/witwpt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAcceptAudience(t *testing.T) {
+	tests := []struct {
+		name     string
+		accepted []string
+		aud      string
+		err      string
+	}{
+		{
+			name:     "exact match",
+			accepted: []string{"https://server.example.org"},
+			aud:      "https://server.example.org",
+		},
+		{
+			name:     "path on the received audience is ignored",
+			accepted: []string{"https://server.example.org"},
+			aud:      "https://server.example.org/v2/orders",
+		},
+		{
+			name:     "query and fragment on the received audience are ignored",
+			accepted: []string{"https://server.example.org"},
+			aud:      "https://server.example.org/v2/orders?page=2#top",
+		},
+		{
+			name:     "path on the configured value is ignored",
+			accepted: []string{"https://server.example.org/v2/"},
+			aud:      "https://server.example.org/v2/orders",
+		},
+		{
+			name:     "trailing slash on either side is ignored",
+			accepted: []string{"https://server.example.org/"},
+			aud:      "https://server.example.org",
+		},
+		{
+			name:     "default https port is dropped from the received audience",
+			accepted: []string{"https://server.example.org"},
+			aud:      "https://server.example.org:443/v2/orders",
+		},
+		{
+			name:     "default https port is dropped from the configured value",
+			accepted: []string{"https://server.example.org:443"},
+			aud:      "https://server.example.org",
+		},
+		{
+			name:     "default http port is dropped",
+			accepted: []string{"http://server.example.org"},
+			aud:      "http://server.example.org:80/health",
+		},
+		{
+			name:     "scheme and host compare case-insensitively",
+			accepted: []string{"https://Server.Example.ORG"},
+			aud:      "HTTPS://server.example.org",
+		},
+		{
+			name:     "non-default port must match",
+			accepted: []string{"https://server.example.org:50051"},
+			aud:      "https://server.example.org:50051/helloworld.Greeter",
+		},
+		{
+			name:     "one of several configured values matches",
+			accepted: []string{"https://a.example.org", "https://b.example.org"},
+			aud:      "https://b.example.org/api",
+		},
+		{
+			name:     "different host is rejected",
+			accepted: []string{"https://b.example.org"},
+			aud:      "https://a.example.org",
+			err: `witwpt: proof audience "https://a.example.org" is not accepted here ` +
+				`(expected one of ["https://b.example.org"])`,
+		},
+		{
+			name:     "different port is rejected",
+			accepted: []string{"https://server.example.org:8443"},
+			aud:      "https://server.example.org:9443",
+			err: `witwpt: proof audience "https://server.example.org:9443" is not accepted here ` +
+				`(expected one of ["https://server.example.org:8443"])`,
+		},
+		{
+			name:     "different scheme is rejected",
+			accepted: []string{"https://server.example.org"},
+			aud:      "http://server.example.org",
+			err: `witwpt: proof audience "http://server.example.org" is not accepted here ` +
+				`(expected one of ["https://server.example.org"])`,
+		},
+		{
+			name:     "empty audience is rejected",
+			accepted: []string{"https://server.example.org"},
+			aud:      "",
+			err:      "witwpt: proof is missing the aud claim",
+		},
+		{
+			name:     "audience without a scheme is rejected",
+			accepted: []string{"https://server.example.org"},
+			aud:      "server.example.org",
+			err:      `witwpt: proof audience "server.example.org" is not a valid absolute URI`,
+		},
+		{
+			name:     "no configured values accepts nothing",
+			accepted: nil,
+			aud:      "https://server.example.org",
+			err: `witwpt: proof audience "https://server.example.org" is not accepted here ` +
+				`(expected one of [])`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := witwpt.AcceptAudience(tt.accepted...)(tt.aud)
+			if tt.err != "" {
+				require.EqualError(t, err, tt.err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestAcceptAudienceReportsMalformedConfiguredValue(t *testing.T) {
+	// A configured value the library cannot normalize must never match, and the
+	// error has to show the operator what they configured so it is diagnosable.
+	err := witwpt.AcceptAudience("not a uri")("https://server.example.org")
+	assert.ErrorContains(t, err, `"not a uri"`)
+}

--- a/exp/witwpt/authorizer.go
+++ b/exp/witwpt/authorizer.go
@@ -1,0 +1,44 @@
+package witwpt
+
+import (
+	"errors"
+
+	"github.com/spiffe/go-spiffe/v2/exp/svid/witsvid"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+)
+
+// Authorizer decides whether an authenticated peer may proceed. It runs only
+// after verification has succeeded, and takes the whole credential rather than a
+// bare SPIFFE ID so it can also read issuer-supplied claims.
+type Authorizer func(svid *witsvid.SVID) error
+
+// AuthorizeAny allows any authenticated peer.
+func AuthorizeAny() Authorizer {
+	return AdaptMatcher(spiffeid.MatchAny())
+}
+
+// AuthorizeID allows a specific SPIFFE ID.
+func AuthorizeID(allowed spiffeid.ID) Authorizer {
+	return AdaptMatcher(spiffeid.MatchID(allowed))
+}
+
+// AuthorizeOneOf allows any SPIFFE ID in the given list of IDs.
+func AuthorizeOneOf(allowed ...spiffeid.ID) Authorizer {
+	return AdaptMatcher(spiffeid.MatchOneOf(allowed...))
+}
+
+// AuthorizeMemberOf allows any SPIFFE ID in the given trust domain.
+func AuthorizeMemberOf(allowed spiffeid.TrustDomain) Authorizer {
+	return AdaptMatcher(spiffeid.MatchMemberOf(allowed))
+}
+
+// AdaptMatcher adapts any spiffeid.Matcher for use as an Authorizer which only
+// authorizes the SPIFFE ID but otherwise ignores the credential.
+func AdaptMatcher(matcher spiffeid.Matcher) Authorizer {
+	return Authorizer(func(svid *witsvid.SVID) error {
+		if svid == nil {
+			return errors.New("no WIT-SVID to authorize")
+		}
+		return matcher(svid.ID)
+	})
+}

--- a/exp/witwpt/authorizer_test.go
+++ b/exp/witwpt/authorizer_test.go
@@ -1,0 +1,106 @@
+package witwpt_test
+
+import (
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/exp/svid/witsvid"
+	"github.com/spiffe/go-spiffe/v2/exp/witwpt"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthorizers(t *testing.T) {
+	var (
+		exampleTD = spiffeid.RequireTrustDomainFromString("example.org")
+		otherTD   = spiffeid.RequireTrustDomainFromString("other.org")
+		client    = spiffeid.RequireFromPath(exampleTD, "/client")
+		server    = spiffeid.RequireFromPath(exampleTD, "/server")
+		stranger  = spiffeid.RequireFromPath(otherTD, "/client")
+	)
+
+	tests := []struct {
+		name       string
+		authorizer witwpt.Authorizer
+		id         spiffeid.ID
+		err        string
+	}{
+		{name: "any allows anyone", authorizer: witwpt.AuthorizeAny(), id: stranger},
+		{name: "id allows the match", authorizer: witwpt.AuthorizeID(client), id: client},
+		{
+			name:       "id rejects another id",
+			authorizer: witwpt.AuthorizeID(client),
+			id:         server,
+			err:        `unexpected ID "spiffe://example.org/server"`,
+		},
+		{
+			name:       "one of allows a listed id",
+			authorizer: witwpt.AuthorizeOneOf(client, server),
+			id:         server,
+		},
+		{
+			name:       "one of rejects an unlisted id",
+			authorizer: witwpt.AuthorizeOneOf(client, server),
+			id:         stranger,
+			err:        `unexpected ID "spiffe://other.org/client"`,
+		},
+		{
+			name:       "member of allows the trust domain",
+			authorizer: witwpt.AuthorizeMemberOf(exampleTD),
+			id:         client,
+		},
+		{
+			name:       "member of rejects another trust domain",
+			authorizer: witwpt.AuthorizeMemberOf(exampleTD),
+			id:         stranger,
+			err:        `unexpected trust domain "other.org"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.authorizer(&witsvid.SVID{ID: tt.id})
+			if tt.err != "" {
+				require.EqualError(t, err, tt.err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestAuthorizerReceivesTheWholeCredential(t *testing.T) {
+	// Passing the SVID rather than a bare ID is what lets an authorizer read
+	// issuer-supplied claims, which tlsconfig.Authorizer cannot do.
+	svid := &witsvid.SVID{
+		ID:     spiffeid.RequireFromString("spiffe://example.org/client"),
+		Claims: map[string]interface{}{"groups": []any{"admin"}},
+	}
+
+	var seen *witsvid.SVID
+	authorizer := witwpt.Authorizer(func(s *witsvid.SVID) error {
+		seen = s
+		return nil
+	})
+
+	require.NoError(t, authorizer(svid))
+	require.Same(t, svid, seen)
+	assert.Equal(t, []any{"admin"}, seen.Claims["groups"])
+}
+
+func TestAdaptMatcher(t *testing.T) {
+	client := spiffeid.RequireFromString("spiffe://example.org/client")
+
+	authorizer := witwpt.AdaptMatcher(spiffeid.MatchID(client))
+	require.NoError(t, authorizer(&witsvid.SVID{ID: client}))
+
+	err := authorizer(&witsvid.SVID{ID: spiffeid.RequireFromString("spiffe://example.org/other")})
+	require.EqualError(t, err, `unexpected ID "spiffe://example.org/other"`)
+}
+
+func TestAuthorizersRejectNilCredential(t *testing.T) {
+	// A nil SVID means verification did not actually produce one; the built-in
+	// authorizers must refuse rather than dereference it.
+	require.Error(t, witwpt.AuthorizeAny()(nil))
+	require.Error(t, witwpt.AuthorizeID(spiffeid.RequireFromString("spiffe://example.org/a"))(nil))
+}

--- a/exp/witwpt/errors.go
+++ b/exp/witwpt/errors.go
@@ -1,0 +1,62 @@
+package witwpt
+
+import "fmt"
+
+// Stage identifies which step of verification rejected a request, so a
+// rejection can be counted and not only logged.
+type Stage int
+
+const (
+	// StageWIT covers validating the WIT-SVID against the trust bundle: its typ,
+	// kid, signature, expiry, subject, and confirmation key.
+	StageWIT Stage = iota + 1
+
+	// StageProof covers verifying the WPT against the confirmation key the
+	// WIT-SVID named, including its binding to that credential and to the target.
+	StageProof
+
+	// StageReplay covers a proof whose jti has already been recorded.
+	StageReplay
+)
+
+// String returns a short, stable label suitable for use as a metric dimension.
+func (s Stage) String() string {
+	switch s {
+	case StageWIT:
+		return "wit"
+	case StageProof:
+		return "proof"
+	case StageReplay:
+		return "replay"
+	default:
+		return "unknown"
+	}
+}
+
+// Error is a verification failure together with the stage that produced it.
+// Verify returns errors of this type so an error handler can count rejections
+// by stage while the remote caller is told only that it was refused.
+type Error struct {
+	// Stage is the step that rejected the request.
+	Stage Stage
+
+	// Err is the underlying cause.
+	Err error
+}
+
+func (e *Error) Error() string {
+	var what string
+	switch e.Stage {
+	case StageWIT:
+		what = "WIT-SVID validation failed"
+	case StageProof:
+		what = "proof verification failed"
+	case StageReplay:
+		what = "replay check failed"
+	default:
+		what = "verification failed"
+	}
+	return fmt.Sprintf("witwpt: %s: %v", what, e.Err)
+}
+
+func (e *Error) Unwrap() error { return e.Err }

--- a/exp/witwpt/errors_test.go
+++ b/exp/witwpt/errors_test.go
@@ -1,0 +1,40 @@
+package witwpt_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/exp/witwpt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStageString(t *testing.T) {
+	// Stage names are used as metric labels, so they are part of the API.
+	assert.Equal(t, "wit", witwpt.StageWIT.String())
+	assert.Equal(t, "proof", witwpt.StageProof.String())
+	assert.Equal(t, "replay", witwpt.StageReplay.String())
+	assert.Equal(t, "unknown", witwpt.Stage(0).String())
+}
+
+func TestErrorCarriesStageAndUnwraps(t *testing.T) {
+	cause := errors.New("boom")
+	err := &witwpt.Error{Stage: witwpt.StageProof, Err: cause}
+
+	t.Run("message names the stage and the cause", func(t *testing.T) {
+		assert.EqualError(t, err, "witwpt: proof verification failed: boom")
+	})
+
+	t.Run("unwraps to the cause", func(t *testing.T) {
+		assert.ErrorIs(t, err, cause)
+	})
+
+	t.Run("errors.As recovers the stage through wrapping", func(t *testing.T) {
+		wrapped := fmt.Errorf("middleware: %w", err)
+
+		var got *witwpt.Error
+		require.ErrorAs(t, wrapped, &got)
+		assert.Equal(t, witwpt.StageProof, got.Stage)
+	})
+}

--- a/exp/witwpt/mint.go
+++ b/exp/witwpt/mint.go
@@ -1,0 +1,160 @@
+// Package witwpt implements the Workload Proof Token (WPT) proof-of-possession
+// protocol for WIT-SVIDs, as specified by draft-ietf-wimse-wpt-01. A workload
+// mints a short-lived WPT signed with the private key matching the WIT-SVID's
+// cnf.jwk claim, binding the proof to the credential (wth) and to the request
+// target (aud).
+//
+// This package is transport neutral. See exp/withttp for the net/http
+// integration.
+package witwpt
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/spiffe/go-spiffe/v2/exp/svid/witsvid"
+)
+
+const (
+	// DefaultProofLifetime is how far ahead a minted proof's exp is set. The
+	// draft calls for a lifetime of "minutes or seconds".
+	DefaultProofLifetime = 60 * time.Second
+
+	// DefaultLeeway is the clock-skew tolerance a verifier applies to a proof's
+	// exp and nbf. It is tighter than the one-minute jwt.DefaultLeeway witsvid
+	// applies to the WIT, which would nearly double a proof's validity.
+	DefaultLeeway = 10 * time.Second
+
+	// DefaultMaxLifetime is the furthest-future exp a verifier accepts,
+	// enforcing wpt-01 §2's rejection of "unreasonably far future" values.
+	DefaultMaxLifetime = 5 * time.Minute
+)
+
+// proofType is the required typ header of a WPT (wpt-01 §2).
+const proofType = "wpt+jwt"
+
+// jtiBytes is the entropy behind each proof's jti, per wpt-01 §2's suggested
+// 128 random bits.
+const jtiBytes = 16
+
+// MintOption configures Mint.
+type MintOption interface {
+	configureMint(*mintConfig)
+}
+
+type mintConfig struct {
+	lifetime time.Duration
+}
+
+type mintOption func(*mintConfig)
+
+func (fn mintOption) configureMint(c *mintConfig) { fn(c) }
+
+// WithProofLifetime sets how far ahead the minted proof's exp is placed,
+// overriding DefaultProofLifetime. Raising it past the verifier's maximum
+// lifetime causes the proof to be rejected.
+func WithProofLifetime(lifetime time.Duration) MintOption {
+	return mintOption(func(c *mintConfig) {
+		c.lifetime = lifetime
+	})
+}
+
+// Mint returns a Workload Proof Token, in JWS compact serialization, proving
+// possession of svid's confirmation key, bound to svid and scoped to audience.
+//
+// audience should be the request target URI without query or fragment
+// (wpt-01 §2). A fresh proof should be minted per request.
+func Mint(svid *witsvid.SVID, audience string, opts ...MintOption) (string, error) {
+	if svid == nil {
+		return "", wrapErr(errors.New("no WIT-SVID provided"))
+	}
+	if audience == "" {
+		return "", wrapErr(errors.New("no audience provided"))
+	}
+	if svid.PrivateKey == nil {
+		return "", wrapErr(errors.New("WIT-SVID has no private key, so possession cannot be proven"))
+	}
+
+	witToken := svid.Marshal()
+	if witToken == "" {
+		return "", wrapErr(errors.New("WIT-SVID has no token to bind the proof to"))
+	}
+
+	// wpt-01 §2 requires the proof's alg to string-equal the WIT's cnf.jwk.alg.
+	alg, err := confirmationAlgorithm(svid)
+	if err != nil {
+		return "", err
+	}
+
+	config := &mintConfig{lifetime: DefaultProofLifetime}
+	for _, opt := range opts {
+		opt.configureMint(config)
+	}
+
+	jti, err := newJTI()
+	if err != nil {
+		return "", err
+	}
+
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: alg, Key: svid.PrivateKey},
+		(&jose.SignerOptions{}).WithType(proofType),
+	)
+	if err != nil {
+		return "", wrapErr(fmt.Errorf("unable to build proof signer: %w", err))
+	}
+
+	now := time.Now()
+	proof, err := jwt.Signed(signer).Claims(map[string]any{
+		"aud": audience,
+		"exp": jwt.NewNumericDate(now.Add(config.lifetime)),
+		"iat": jwt.NewNumericDate(now),
+		"jti": jti,
+		"wth": WITThumbprint(witToken),
+	}).Serialize()
+	if err != nil {
+		return "", wrapErr(fmt.Errorf("unable to sign proof: %w", err))
+	}
+	return proof, nil
+}
+
+// WITThumbprint returns the wth claim value binding a proof to a WIT-SVID:
+// base64url(SHA-256(ASCII(token))) over the compact serialization, per
+// wpt-01 §2. This hashes the token itself, not an RFC 7638 JWK thumbprint of
+// the confirmation key.
+func WITThumbprint(witToken string) string {
+	sum := sha256.Sum256([]byte(witToken))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+// confirmationAlgorithm reads cnf.jwk.alg from the credential's claims. witsvid
+// already validated it is present and a supported asymmetric algorithm.
+func confirmationAlgorithm(svid *witsvid.SVID) (jose.SignatureAlgorithm, error) {
+	cnf, ok := svid.Claims["cnf"].(map[string]any)
+	if !ok {
+		return "", wrapErr(errors.New("WIT-SVID claims have no cnf object"))
+	}
+	jwk, ok := cnf["jwk"].(map[string]any)
+	if !ok {
+		return "", wrapErr(errors.New("WIT-SVID cnf claim has no jwk object"))
+	}
+	alg, ok := jwk["alg"].(string)
+	if !ok || alg == "" {
+		return "", wrapErr(errors.New("WIT-SVID cnf.jwk has no alg"))
+	}
+	return jose.SignatureAlgorithm(alg), nil
+}
+
+func newJTI() (string, error) {
+	raw := make([]byte, jtiBytes)
+	if _, err := rand.Read(raw); err != nil {
+		return "", wrapErr(fmt.Errorf("unable to generate proof id: %w", err))
+	}
+	return base64.RawURLEncoding.EncodeToString(raw), nil
+}

--- a/exp/witwpt/mint_test.go
+++ b/exp/witwpt/mint_test.go
@@ -1,0 +1,281 @@
+package witwpt_test
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/spiffe/go-spiffe/v2/exp/svid/witsvid"
+	"github.com/spiffe/go-spiffe/v2/exp/witwpt"
+	"github.com/spiffe/go-spiffe/v2/internal/test"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// witFixture is a committed WIT-SVID whose exp is 2100-01-01, so it does not
+// rot. Its signature is a fixed 64-byte filler: ParseInsecure does not verify
+// signatures, and holding the token bytes constant is what makes wantWTH below
+// a stable, independently checkable value.
+const witFixture = "eyJhbGciOiJFUzI1NiIsImtpZCI6IndpdC1hdXRob3JpdHktMSIsInR5cCI6IndpdCtqd3QifQ." +
+	"eyJjbmYiOnsiandrIjp7ImFsZyI6IkVTMjU2IiwiY3J2IjoiUC0yNTYiLCJraWQiOiJjbmYtMSIsImt0eSI6IkVDIiwi" +
+	"eCI6ImlLWnM3QzlPTWFrWm9DTkZDSmpjSWU4aHB4QkR2SGVDSTJsdzVnRVR1dWsiLCJ5IjoieHkzMGFfYzJ3YmduMkxl" +
+	"SV9od28xRVR3S2tzb0szemlTZGVyM2loOTR3OCJ9fSwiZXhwIjo0MTAyNDQ0ODAwLCJpYXQiOjE3NTAwMDAwMDAsImlz" +
+	"cyI6InNwaWZmZTovL2V4YW1wbGUub3JnIiwic3ViIjoic3BpZmZlOi8vZXhhbXBsZS5vcmcvY2xpZW50In0." +
+	"AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0-Pw"
+
+// witFixturePrivJWK is the private half of witFixture's cnf.jwk. It is a test
+// fixture, not a credential.
+const witFixturePrivJWK = `{"kty":"EC","kid":"cnf-1","crv":"P-256","alg":"ES256",` +
+	`"x":"iKZs7C9OMakZoCNFCJjcIe8hpxBDvHeCI2lw5gETuuk",` +
+	`"y":"xy30a_c2wbgn2LeI_hwo1ETwKksoK3ziSder3ih94w8",` +
+	`"d":"i7Q5Wgfd1jPpqMlApObMNHhkyTSEnVVLKtLfIOizFPE"}`
+
+// wantWTH is base64url(SHA-256(ASCII(witFixture))) per draft-ietf-wimse-wpt-01
+// §2 -- a hash of the whole compact serialization, NOT an RFC 7638 JWK
+// thumbprint. Derived without this package's code, and reproducible with:
+//
+//	printf '%s' "$WIT" | openssl dgst -sha256 -binary | base64 | tr '+/' '-_' | tr -d '='
+const wantWTH = "YbWmBlkKlYIC8qAmT-RLp-ZWyPIfrijSxszwpN3CUyQ"
+
+const testAudience = "https://server.example.org/v2/orders"
+
+// TestMintWTHMatchesIndependentlyDerivedConstant is the anchor test for the
+// single highest-risk value in the implementation: the wrong reading of wth
+// (a JWK thumbprint) would still round-trip against our own verifier.
+func TestMintWTHMatchesIndependentlyDerivedConstant(t *testing.T) {
+	svid := fixtureSVID(t)
+
+	proof, err := witwpt.Mint(svid, testAudience)
+	require.NoError(t, err)
+
+	claims := parseProofClaims(t, proof, svid.PublicKey)
+	assert.Equal(t, wantWTH, claims["wth"],
+		"wth must be base64url(SHA-256(WIT compact serialization))")
+
+	// Guard against the tempting-but-wrong RFC 7638 thumbprint reading.
+	thumbprint, err := (&jose.JSONWebKey{Key: svid.PublicKey}).Thumbprint(crypto.SHA256)
+	require.NoError(t, err)
+	assert.NotEqual(t, base64.RawURLEncoding.EncodeToString(thumbprint), claims["wth"],
+		"wth must not be the JWK thumbprint")
+}
+
+func TestMintClaimAndHeaderShape(t *testing.T) {
+	svid := fixtureSVID(t)
+
+	before := time.Now()
+	proof, err := witwpt.Mint(svid, testAudience)
+	require.NoError(t, err)
+
+	tok, err := jwt.ParseSigned(proof, allProofAlgorithms)
+	require.NoError(t, err)
+
+	t.Run("typ header is wpt+jwt", func(t *testing.T) {
+		assert.Equal(t, "wpt+jwt", tok.Headers[0].ExtraHeaders[jose.HeaderType])
+	})
+
+	claims := parseProofClaims(t, proof, svid.PublicKey)
+
+	t.Run("aud is the full target URI, query and fragment aside", func(t *testing.T) {
+		assert.Equal(t, testAudience, claims["aud"])
+	})
+
+	t.Run("exp defaults to DefaultProofLifetime ahead", func(t *testing.T) {
+		exp := numericDate(t, claims["exp"])
+		assert.WithinDuration(t, before.Add(witwpt.DefaultProofLifetime), exp, 5*time.Second)
+	})
+
+	t.Run("jti is present", func(t *testing.T) {
+		assert.NotEmpty(t, claims["jti"])
+	})
+
+	t.Run("no aud-free or identity claims are invented", func(t *testing.T) {
+		// The WPT carries no identity; sub must not appear.
+		assert.NotContains(t, claims, "sub")
+	})
+}
+
+func TestMintAlgTracksCnfJWKAlg(t *testing.T) {
+	// wpt-01 §2 requires the proof's alg to string-equal the WIT's cnf.jwk.alg,
+	// so it is read from the credential rather than chosen by us.
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	ecKey := test.NewEC256Key(t)
+
+	tests := []struct {
+		alg jose.SignatureAlgorithm
+		key crypto.Signer
+	}{
+		{alg: jose.ES256, key: ecKey},
+		{alg: jose.RS256, key: rsaKey},
+		{alg: jose.PS256, key: rsaKey},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.alg), func(t *testing.T) {
+			svid := makeWITSVID(t, tt.alg, tt.key)
+
+			proof, err := witwpt.Mint(svid, testAudience)
+			require.NoError(t, err)
+
+			tok, err := jwt.ParseSigned(proof, allProofAlgorithms)
+			require.NoError(t, err)
+			assert.Equal(t, string(tt.alg), tok.Headers[0].Algorithm)
+
+			// And the signature really verifies under the cnf public key.
+			var claims map[string]any
+			require.NoError(t, tok.Claims(tt.key.Public(), &claims))
+		})
+	}
+}
+
+func TestMintJTIIsUniqueAndAtLeast128Bits(t *testing.T) {
+	svid := fixtureSVID(t)
+
+	seen := make(map[string]struct{})
+	for range 50 {
+		proof, err := witwpt.Mint(svid, testAudience)
+		require.NoError(t, err)
+
+		jti, ok := parseProofClaims(t, proof, svid.PublicKey)["jti"].(string)
+		require.True(t, ok, "jti must be a string")
+
+		raw, err := base64.RawURLEncoding.DecodeString(jti)
+		require.NoError(t, err, "jti should be base64url")
+		assert.GreaterOrEqual(t, len(raw)*8, 128, "jti must carry at least 128 bits of entropy")
+
+		_, duplicate := seen[jti]
+		require.False(t, duplicate, "jti must not repeat")
+		seen[jti] = struct{}{}
+	}
+}
+
+func TestMintWithProofLifetime(t *testing.T) {
+	svid := fixtureSVID(t)
+
+	before := time.Now()
+	proof, err := witwpt.Mint(svid, testAudience, witwpt.WithProofLifetime(5*time.Second))
+	require.NoError(t, err)
+
+	exp := numericDate(t, parseProofClaims(t, proof, svid.PublicKey)["exp"])
+	assert.WithinDuration(t, before.Add(5*time.Second), exp, 2*time.Second)
+}
+
+func TestMintErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		svid func(*testing.T) *witsvid.SVID
+		aud  string
+		err  string
+	}{
+		{
+			name: "nil SVID",
+			svid: func(*testing.T) *witsvid.SVID { return nil },
+			aud:  testAudience,
+			err:  "witwpt: no WIT-SVID provided",
+		},
+		{
+			name: "SVID without a private key cannot prove possession",
+			svid: func(t *testing.T) *witsvid.SVID {
+				svid := fixtureSVID(t)
+				svid.PrivateKey = nil
+				return svid
+			},
+			aud: testAudience,
+			err: "witwpt: WIT-SVID has no private key, so possession cannot be proven",
+		},
+		{
+			name: "empty audience",
+			svid: fixtureSVID,
+			aud:  "",
+			err:  "witwpt: no audience provided",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proof, err := witwpt.Mint(tt.svid(t), tt.aud)
+			require.EqualError(t, err, tt.err)
+			assert.Empty(t, proof)
+		})
+	}
+}
+
+// --- helpers ---
+
+var allProofAlgorithms = []jose.SignatureAlgorithm{
+	jose.RS256, jose.RS384, jose.RS512,
+	jose.ES256, jose.ES384, jose.ES512,
+	jose.PS256, jose.PS384, jose.PS512,
+}
+
+// fixtureSVID parses witFixture and attaches its committed private key, giving
+// an SVID whose token bytes -- and therefore whose wth -- are constant.
+func fixtureSVID(t *testing.T) *witsvid.SVID {
+	t.Helper()
+	svid, err := witsvid.ParseInsecure(witFixture)
+	require.NoError(t, err)
+	require.Equal(t, witFixture, svid.Marshal())
+
+	var jwk jose.JSONWebKey
+	require.NoError(t, jwk.UnmarshalJSON([]byte(witFixturePrivJWK)))
+	svid.PrivateKey = jwk.Key
+	return svid
+}
+
+// makeWITSVID builds a WIT-SVID whose cnf.jwk.alg is alg and whose confirmation
+// key is key, for cases where the token bytes need not be fixed.
+func makeWITSVID(t *testing.T, alg jose.SignatureAlgorithm, key crypto.Signer) *witsvid.SVID {
+	t.Helper()
+
+	cnfJWK := jose.JSONWebKey{Key: key.Public(), KeyID: "cnf-1", Algorithm: string(alg)}
+	cnfBytes, err := cnfJWK.MarshalJSON()
+	require.NoError(t, err)
+	var cnfMap map[string]any
+	require.NoError(t, json.Unmarshal(cnfBytes, &cnfMap))
+
+	authority := test.NewEC256Key(t)
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.ES256, Key: jose.JSONWebKey{Key: authority, KeyID: "auth-1"}},
+		(&jose.SignerOptions{}).WithType("wit+jwt"),
+	)
+	require.NoError(t, err)
+
+	token, err := jwt.Signed(signer).Claims(map[string]any{
+		"sub": spiffeid.RequireFromString("spiffe://example.org/client").String(),
+		"exp": jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		"cnf": map[string]any{"jwk": cnfMap},
+	}).Serialize()
+	require.NoError(t, err)
+
+	svid, err := witsvid.ParseInsecure(token)
+	require.NoError(t, err)
+	svid.PrivateKey = key
+	return svid
+}
+
+// parseProofClaims parses a proof and verifies its signature under pub, then
+// returns its claims. It never routes through this package's Verify, so mint
+// coverage does not depend on verify being correct.
+func parseProofClaims(t *testing.T, proof string, pub crypto.PublicKey) map[string]any {
+	t.Helper()
+	tok, err := jwt.ParseSigned(proof, allProofAlgorithms)
+	require.NoError(t, err)
+
+	var claims map[string]any
+	require.NoError(t, tok.Claims(pub, &claims))
+	return claims
+}
+
+func numericDate(t *testing.T, raw any) time.Time {
+	t.Helper()
+	seconds, ok := raw.(float64)
+	require.True(t, ok, "expected a JSON number, got %T", raw)
+	return time.Unix(int64(seconds), 0)
+}

--- a/workloadapi/witsource.go
+++ b/workloadapi/witsource.go
@@ -125,6 +125,25 @@ func (s *WITSource) Close() error {
 	return s.closeBase(closer)
 }
 
+// GetWITSVID returns the default WIT-SVID, which is the first one in the list
+// returned by the Workload API (see the SPIFFE Workload API specification §8).
+// It implements the witsvid.Source interface.
+//
+// Experimental: subject to change.
+func (s *WITSource) GetWITSVID() (*witsvid.SVID, error) {
+	if err := s.checkClosed(); err != nil {
+		return nil, err
+	}
+
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+
+	if len(s.svids) == 0 {
+		return nil, errors.New("witsource: no WIT-SVID available")
+	}
+	return s.svids[0], nil
+}
+
 // GetWITSVIDForID returns the WIT-SVID for the given SPIFFE ID.
 // It implements the witsvid.Source interface.
 //

--- a/workloadapi/witsource_test.go
+++ b/workloadapi/witsource_test.go
@@ -71,6 +71,41 @@ func TestWITSourceLookup(t *testing.T) {
 	})
 }
 
+func TestWITSourceGetWITSVID(t *testing.T) {
+	t.Run("returns the first SVID as the default identity", func(t *testing.T) {
+		api := fakeworkloadapi.New(t)
+		t.Cleanup(api.Stop)
+
+		key := test.NewEC256Key(t)
+		kid := "key-1"
+		api.SetWITSVIDResponse(&workload.WITSVIDResponse{
+			Svids: []*workload.WITSVID{
+				makeWITSVIDProto(t, witFooID, key, test.NewEC256Key(t), kid, ""),
+				makeWITSVIDProto(t, witBarID, key, test.NewEC256Key(t), kid, ""),
+			},
+		})
+		api.SetWITBundles(makeWITBundle(t, witTD, key, kid))
+
+		src, err := workloadapi.NewWITSource(t.Context(), withAddr(api))
+		require.NoError(t, err)
+		t.Cleanup(func() { src.Close() })
+
+		svid, err := src.GetWITSVID()
+		require.NoError(t, err)
+		assert.Equal(t, witFooID, svid.ID)
+	})
+
+	t.Run("errors when the source holds no SVIDs", func(t *testing.T) {
+		// Not reachable through NewWITSource: parseWITSVIDs rejects an empty
+		// response and watchWITSVIDs routes that to OnWITSVIDsWatchError, so
+		// OnWITSVIDsUpdate never delivers an empty slice. The branch is
+		// defensive; this pins its error rather than a nil SVID.
+		var src workloadapi.WITSource
+		_, err := src.GetWITSVID()
+		require.EqualError(t, err, "witsource: no WIT-SVID available")
+	})
+}
+
 func TestWITSourceClose(t *testing.T) {
 	api := fakeworkloadapi.New(t)
 	t.Cleanup(api.Stop)
@@ -80,6 +115,9 @@ func TestWITSourceClose(t *testing.T) {
 
 	t.Run("post-close calls return error", func(t *testing.T) {
 		_, err := src.GetWITSVIDForID(witFooID)
+		require.EqualError(t, err, "witsource: source is closed")
+
+		_, err = src.GetWITSVID()
 		require.EqualError(t, err, "witsource: source is closed")
 
 		_, err = src.GetWITBundleForTrustDomain(witTD)


### PR DESCRIPTION
Add exp/witwpt, the WPT protocol core: minting and policy

Introduces the transport-neutral core of WPT (workload proof token)   authentication for WIT-SVIDs, covering the presenting side and the   policy helpers a verifier composes with.